### PR TITLE
Handle Executive positions

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,9 @@ optional columns:
 An optional `group_id` can also be given, if you wish to use predefined
 identifiers, otherwise a unique ID will be allocated.
 
+## Executive Posts
+
+If members of the legislature can also hold executive positions (e.g.
+Prime Minister; Minister of Education; etc) these can be specified in an
+`executive` column. 
+

--- a/lib/csv_to_popolo.rb
+++ b/lib/csv_to_popolo.rb
@@ -41,11 +41,11 @@ class Popolo
     end
 
     def organizations
-      parties + legislatures
+      parties + legislatures + executive
     end
 
     def memberships 
-      party_memberships + legislative_memberships
+      party_memberships + legislative_memberships + executive_memberships
     end
 
     def parties 
@@ -68,6 +68,14 @@ class Popolo
       }]
     end
 
+    def executive
+      [{
+        id: 'executive',
+        name: 'Executive', 
+        classification: 'executive',
+      }]
+    end
+
     def party_memberships 
       @_pmems ||= @csv.find_all { |r| r.has_key? :group }.map do |r|
         { 
@@ -80,10 +88,22 @@ class Popolo
 
     def legislative_memberships 
       @_lmems ||= @csv.find_all { |r| r.has_key? :group }.map do |r|
-        { 
+        mem = { 
           person_id:        r[:id],
           organization_id:  'legislature',
           role:             'representative',
+        }
+        mem[:area] = { name: r[:area] } if r.has_key? :area and !r[:area].nil?
+        mem
+      end
+    end
+
+    def executive_memberships 
+      @_emems ||= @csv.find_all { |r| r.has_key? :post and !r[:post].nil? }.map do |r|
+        { 
+          person_id:        r[:id],
+          organization_id:  'executive',
+          role:             r[:post],
         }
       end
     end

--- a/lib/csv_to_popolo.rb
+++ b/lib/csv_to_popolo.rb
@@ -99,11 +99,11 @@ class Popolo
     end
 
     def executive_memberships 
-      @_emems ||= @csv.find_all { |r| r.has_key? :post and !r[:post].nil? }.map do |r|
+      @_emems ||= @csv.find_all { |r| r.has_key? :executive and !r[:executive].nil? }.map do |r|
         { 
           person_id:        r[:id],
           organization_id:  'executive',
-          role:             r[:post],
+          role:             r[:executive],
         }
       end
     end

--- a/lib/csv_to_popolo/version.rb
+++ b/lib/csv_to_popolo/version.rb
@@ -1,3 +1,3 @@
 module Popolo_CSV
-  VERSION = "0.5"
+  VERSION = "0.5.1"
 end

--- a/t/data/welsh_assembly.csv
+++ b/t/data/welsh_assembly.csv
@@ -1,4 +1,4 @@
-group,name,area,en_constituency_name,en_title,en_party_name,href,post,en_region_name,other_name,id
+group,name,area,en_constituency_name,en_title,en_party_name,href,executive,en_region_name,other_name,id
 Welsh Labour,Lesley Griffiths,Wrexham,Wrexham,The Minister for Communities and Tackling Poverty,Welsh Labour,http://www.senedd.assemblywales.org/mgUserInfo.aspx?UID=154,The Minister for Communities and Tackling Poverty,,,http://www.senedd.assemblywales.org/mgUserInfo.aspx?UID=154
 Welsh Labour,Carl Sargeant,Alyn and Deeside,Alyn and Deeside,The Minister for Natural Resources,Welsh Labour,http://www.senedd.assemblywales.org/mgUserInfo.aspx?UID=178,The Minister for Natural Resources,,,http://www.senedd.assemblywales.org/mgUserInfo.aspx?UID=178
 Welsh Labour,Janice Gregory,Ogmore,Ogmore,,Welsh Labour,http://www.senedd.assemblywales.org/mgUserInfo.aspx?UID=152,,,,http://www.senedd.assemblywales.org/mgUserInfo.aspx?UID=152

--- a/t/test_wales.rb
+++ b/t/test_wales.rb
@@ -50,5 +50,31 @@ describe "welsh assembly" do
 
   end
 
+  describe "First Minister" do
+    
+    let(:executive) { subject.data[:organizations].find { |o| o[:id] == 'executive' } }
+    let(:fmin) { subject.data[:persons].find         { |p| p[:id].end_with? '=102' } }
+    let(:mems) { subject.data[:memberships].find_all { |m| m[:person_id] == fmin[:id] } }
+
+    it "should have three memberships" do
+      mems.count.must_equal 3
+    end
+
+    it "should have Assembly membership" do
+      mems.find { |m| m[:role] == 'representative' }[:area][:name].must_equal 'Bridgend'
+    end
+
+    it "should have Party membership" do
+      mems.find { |m| m[:role] == 'party representative' }[:organization_id].must_match /^party/
+    end
+
+    it "should have Executive membership" do
+      execm = mems.find_all { |m| m[:organization_id] == executive[:id] }
+      execm.count.must_equal 1
+      execm.first[:role].must_equal 'The First Minister'
+    end
+
+  end
 
 end
+


### PR DESCRIPTION
An `executive` column  can contain Executive-level positions. 

These are implemented as plain Memberships with Roles for now; later we may make them Posts.
