### PR TITLE
IDs should be Strings

### DIFF
--- a/lib/csv_to_popolo.rb
+++ b/lib/csv_to_popolo.rb
@@ -7,7 +7,6 @@ class Popolo
 
     @@opts = { 
       headers:           true,
-      converters:        :numeric,
       header_converters: :symbol 
     }
     

--- a/lib/csv_to_popolo/version.rb
+++ b/lib/csv_to_popolo/version.rb
@@ -1,3 +1,3 @@
 module Popolo_CSV
-  VERSION = "0.5.2"
+  VERSION = "0.5.3"
 end

--- a/t/test_eduskunta.rb
+++ b/t/test_eduskunta.rb
@@ -9,8 +9,8 @@ describe "eduskunta" do
     Popolo::CSV.from_file('t/data/eduskunta.csv')
   }
 
-  let(:ahde)  { subject.data[:persons].find           { |p| p[:id] == 104 } }
-  let(:mems)  { subject.data[:memberships].find_all   { |m| m[:person_id] == 104 } }
+  let(:ahde)  { subject.data[:persons].find           { |p| p[:id] == '104' } }
+  let(:mems)  { subject.data[:memberships].find_all   { |m| m[:person_id] == '104' } }
   let(:kesk)  { subject.data[:organizations].find     { |o| o[:name] == 'Finnish Centre Party' } }
 
   it "should set party name correctly" do

--- a/t/test_eduskunta_mini.rb
+++ b/t/test_eduskunta_mini.rb
@@ -9,15 +9,15 @@ describe "eduskunta" do
     Popolo::CSV.from_file('t/data/eduskunta_mini.csv')
   }
 
-  let(:ahde)  { subject.data[:persons].find { |i| i[:id] == 104 } }
-  let(:mems)  { subject.data[:memberships].find_all { |i| i[:person_id] == 104 } }
+  let(:ahde)  { subject.data[:persons].find { |i| i[:id] == '104' } }
+  let(:mems)  { subject.data[:memberships].find_all { |i| i[:person_id] == '104' } }
 
   it "should have the correct name" do
     ahde[:name].must_equal 'Aho Esko'
   end
 
   it "should have the correct id" do
-    ahde[:id].must_equal 104
+    ahde[:id].must_equal '104'
   end
 
   it "should have the correct family name" do
@@ -37,3 +37,5 @@ describe "eduskunta" do
   end
 
 end
+
+


### PR DESCRIPTION
Don’t convert numeric CSV rows to integers. Popolo requires them to be
Strings. Closes #14
