### PR TITLE
Change role names

### DIFF
--- a/lib/csv_to_popolo.rb
+++ b/lib/csv_to_popolo.rb
@@ -87,7 +87,7 @@ class Popolo
         { 
           person_id: r[:id],
           organization_id: r[:group_id] || find_party_id(r[:group]),
-          role: 'party representative',
+          role: 'representative',
           start_date: r[:start_date],
           end_date: r[:end_date],
         }.select { |_, v| !v.nil? } 
@@ -99,7 +99,7 @@ class Popolo
         mem = { 
           person_id:        r[:id],
           organization_id:  'legislature',
-          role:             'representative',
+          role:             'member',
         }
         mem[:area] = { name: r[:area] } if r.has_key? :area and !r[:area].nil?
         mem

--- a/lib/csv_to_popolo/version.rb
+++ b/lib/csv_to_popolo/version.rb
@@ -1,3 +1,3 @@
 module Popolo_CSV
-  VERSION = "0.6.3"
+  VERSION = "0.6.4"
 end

--- a/t/test_eduskunta.rb
+++ b/t/test_eduskunta.rb
@@ -24,7 +24,7 @@ describe "eduskunta" do
   end
 
   it "should only have correct party membership" do
-    pm = mems.find_all { |m| m[:role] == 'party representative' }
+    pm = mems.find_all { |m| m[:role] == 'representative' }
     pm.count.must_equal 1
     pm.first[:organization_id].must_equal 'kesk'
   end

--- a/t/test_riigikogu.rb
+++ b/t/test_riigikogu.rb
@@ -28,7 +28,7 @@ describe "riigikogu" do
 
     it "should have nested faction info" do
       mems.count.must_equal 2
-      party_mem = mems.find { |m| m[:role] == 'party representative' }
+      party_mem = mems.find { |m| m[:role] == 'representative' }
       party = orgs.find { |o| party_mem[:organization_id] == o[:id] }
       party[:name].must_equal 'Eesti Reformierakonna fraktsioon'
       party[:classification].must_equal 'party'
@@ -45,7 +45,7 @@ describe "riigikogu" do
 
     it "should have start_date" do
       mems.count.must_equal 2
-      party_mem = mems.find { |m| m[:role] == 'party representative' }
+      party_mem = mems.find { |m| m[:role] == 'representative' }
       party = orgs.find { |o| party_mem[:organization_id] == o[:id] }
       party[:name].must_equal 'Eesti Reformierakonna fraktsioon'
       party_mem[:start_date].must_equal '2011-04-02'
@@ -60,7 +60,7 @@ describe "riigikogu" do
     let(:mems)   { subject.data[:memberships].find_all { |m| m[:person_id] == andres[:id] } }
 
     it "should have start_date and end_date" do
-      party_mem = mems.find { |m| m[:role] == 'party representative' }
+      party_mem = mems.find { |m| m[:role] == 'representative' }
       party = orgs.find { |o| party_mem[:organization_id] == o[:id] }
       party[:name].must_equal 'Isamaa ja Res Publica Liidu fraktsioon'
       party_mem[:start_date].must_equal '2011-12-06'

--- a/t/test_tcamp.rb
+++ b/t/test_tcamp.rb
@@ -24,7 +24,7 @@ describe "tcamp" do
     end
 
     it "should rename the org name" do
-      pmem = mems.find { |m| m[:role] == 'party representative' }
+      pmem = mems.find { |m| m[:role] == 'representative' }
       oids = orgs.map { |o| o[:id] }
       party = orgs.find { |o| o[:id] == pmem[:organization_id] }
       party[:name].must_equal 'mySociety'

--- a/t/test_wales.rb
+++ b/t/test_wales.rb
@@ -72,11 +72,11 @@ describe "welsh assembly" do
     end
 
     it "should have Assembly membership" do
-      mems.find { |m| m[:role] == 'representative' }[:area][:name].must_equal 'Bridgend'
+      mems.find { |m| m[:role] == 'member' }[:area][:name].must_equal 'Bridgend'
     end
 
     it "should have Party membership" do
-      mems.find { |m| m[:role] == 'party representative' }[:organization_id].must_match /^party/
+      mems.find { |m| m[:role] == 'representative' }[:organization_id].must_match /^party/
     end
 
     it "should have Executive membership" do


### PR DESCRIPTION
In order to read better in PopIt’s UI, but also be different enough to filter on, make the legislative membership be of role ‘member’, and the party members of role ‘representative’.
