### PR TITLE
We shouldn't need to set a mime-type on images

### DIFF
--- a/lib/csv_to_popolo.rb
+++ b/lib/csv_to_popolo.rb
@@ -172,7 +172,6 @@ class Popolo
       popolo[:contact_details] = contact_details
       popolo[:images] = [{ 
         url: @r[:image],
-        mime_type: 'image/jpeg',
       }] if @r[:image]
 
       if given? :other_name

--- a/lib/csv_to_popolo/version.rb
+++ b/lib/csv_to_popolo/version.rb
@@ -1,3 +1,3 @@
 module Popolo_CSV
-  VERSION = "0.6.13"
+  VERSION = "0.6.14"
 end


### PR DESCRIPTION
We added this to try to work around various other issues, but we don’t
actually need to set our own mime-type.

Closes https://github.com/mysociety/openpoliticians/issues/55
