### PR TITLE
Handle column names with spaces

### DIFF
--- a/lib/csv_to_popolo.rb
+++ b/lib/csv_to_popolo.rb
@@ -15,7 +15,7 @@ class Popolo
       type: 'asis',
     },
     birth_date: { 
-      aliases: %w(dob),
+      aliases: %w(dob date_of_birth),
       type: 'asis',
     },
     cell: { 
@@ -114,7 +114,9 @@ class Popolo
     @@opts = {
       headers: true,
       header_converters: lambda { |h| 
-        (@@key_map[h.downcase] || h.downcase).to_sym
+        # = HeaderConverters.symbol + remapping
+        hc = h.encode(::CSV::ConverterEncoding).downcase.gsub(/\s+/, "_").gsub(/\W+/, "")
+        (@@key_map[hc] || hc).to_sym
       }
     }
 

--- a/t/data/mac.csv
+++ b/t/data/mac.csv
@@ -1,1 +1,1 @@
-Name,Constituency,Gender,DOBPaul Paul,Eyeton,Male,31/12/99Helen Helen,Beaton,Female,01/01/80
+Name,Constituency,Gender,"Date of Birth"Paul Paul,Eyeton,Male,31/12/99Helen Helen,Beaton,Female,01/01/80


### PR DESCRIPTION
As we’re providing our own `header_converter`, we should replicate the
inbuilt `:symbol` converter before doing our remapping. Closes #38 
