### PR TITLE
Handle various external links

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ It currently handles data from the following columns:
 * `phone`
 * `fax`
 * `cell`
+* `twitter`
 * `gender`
 * `birth_date`
 * `death_date`
@@ -33,7 +34,6 @@ It currently handles data from the following columns:
 * `summary`
 * `biography`
 * `national_identity`
-* `twitter`
 
 (none of these are required — it will simply extra data from any
 suitably-named columns)
@@ -62,4 +62,17 @@ membership.
 If members of the legislature can also hold executive positions (e.g.
 Prime Minister; Minister of Education; etc) these can be specified in an
 `executive` column. 
+
+## Other Links
+
+Any of the following columns will be turned into suitable "External
+Links" data:
+
+* `website`
+* `blog`
+* `facebook`
+* `flickr`
+* `instagram`
+* `wikipedia`
+* `youtube`
 

--- a/lib/csv_to_popolo.rb
+++ b/lib/csv_to_popolo.rb
@@ -18,6 +18,9 @@ class Popolo
       aliases: %w(dob date_of_birth),
       type: 'asis',
     },
+    blog: { 
+      type: 'link',
+    },
     cell: { 
       aliases: %w(mobile),
       type: 'contact',
@@ -34,6 +37,9 @@ class Popolo
     executive: { 
       aliases: %w(post),
     },
+    facebook: { 
+      type: 'link',
+    },
     family_name: { 
       aliases: %w(last_name),
       type: 'asis',
@@ -42,6 +48,9 @@ class Popolo
       aliases: %w(facsimile),
       type: 'contact',
     }, 
+    flickr: { 
+      type: 'link',
+    },
     gender: { 
       type: 'asis',
     },
@@ -70,6 +79,12 @@ class Popolo
       aliases: %w(img picture photo portrait),
       type: 'asis',
     },
+    instagram: { 
+      type: 'link',
+    },
+    linkedin: { 
+      type: 'link',
+    },
     name: { 
       type: 'asis',
     },
@@ -95,6 +110,16 @@ class Popolo
     twitter: { 
       type: 'contact',
     }, 
+    website: { 
+      type: 'link',
+      aliases: %w(homepage href url),
+    },
+    wikipedia: { 
+      type: 'link',
+    },
+    youtube: { 
+      type: 'link',
+    },
     
     other_name: { },
   }
@@ -252,8 +277,20 @@ class Popolo
       return contacts.length.zero? ? nil : contacts
     end
 
-    def as_popolo
+    def links
+      link_types = Popolo.model.find_all { |k, v| v[:type] == 'link' }.map { |k,v| k }
+      links = link_types.map { |type|
+        if given? type
+          {
+            url: @r[type],
+            note: type.to_s,
+          }
+        end
+      }.compact
+      return links.length.zero? ? nil : links
+    end
 
+    def as_popolo
       popolo = {}
       as_is = Popolo.model.find_all { |k, v| v[:type] == 'asis' }.map { |k,v| k }
       as_is.each do |sym|
@@ -261,6 +298,7 @@ class Popolo
       end
 
       popolo[:contact_details] = contact_details
+      popolo[:links] = links
       popolo[:images] = [{ 
         url: @r[:image],
       }] if @r[:image]

--- a/lib/csv_to_popolo/version.rb
+++ b/lib/csv_to_popolo/version.rb
@@ -1,3 +1,3 @@
 module Popolo_CSV
-  VERSION = "0.7.2"
+  VERSION = "0.7.3"
 end

--- a/t/data/tcamp.csv
+++ b/t/data/tcamp.csv
@@ -1,4 +1,4 @@
-org,first_name,last_name,twitter,mobile,fax
-mySociety,Tom,Steinberg,steiny,tomsphone,
-Sunlight Foundation,Ellen,Miller,EllnMllr,ellensphone,ellensfax
+org,first_name,last_name,twitter,mobile,fax,wikipedia
+mySociety,Tom,Steinberg,steiny,tomsphone,,http://en.wikipedia.org/wiki/Tom_Steinberg
+Sunlight Foundation,Ellen,Miller,EllnMllr,ellensphone,ellensfax,http://en.wikipedia.org/wiki/Ellen_S._Miller
 ,Orgless,,,,,

--- a/t/test_tcamp.rb
+++ b/t/test_tcamp.rb
@@ -42,6 +42,10 @@ describe "tcamp" do
       steiny[:contact_details].find { |c| c[:type] == 'fax' }.must_be_nil
     end
 
+    it "should have a wikipedia page" do
+      steiny[:links].find { |l| l[:note] == 'wikipedia' }[:url].must_equal 'http://en.wikipedia.org/wiki/Tom_Steinberg'
+    end
+
   end
 
   describe "ellen" do

--- a/t/test_wales.rb
+++ b/t/test_wales.rb
@@ -34,6 +34,14 @@ describe "welsh assembly" do
       asghar[:contact_details].first[:value].must_equal '01633 220022'
     end
 
+    it "should have a website" do
+      asghar[:links].class.must_equal Array
+      asghar[:links].count.must_equal 1
+      asghar[:links].first.class.must_equal Hash
+      asghar[:links].first[:url].must_equal 'http://www.senedd.assemblywales.org/mgUserInfo.aspx?UID=130'
+      asghar[:links].first[:note].must_equal 'website'
+    end
+
   end
 
   describe "Parties" do
@@ -90,7 +98,7 @@ describe "welsh assembly" do
   describe "validation" do
 
     it "should have skipped unknown columns" do
-      subject.data[:warnings][:skipped].must_include :href
+      subject.data[:warnings][:skipped].must_include :en_title
     end
 
     it "should validate" do


### PR DESCRIPTION
Allow columns called `website`, `blog`, `facebook`, `flickr`,
`instagram`, `wikipedia`, `youtube`,  and various other aliases
(`homepage`, `href`, `url`)
