### PR TITLE
Allow files with multiple chambers

### DIFF
--- a/lib/csv_to_popolo.rb
+++ b/lib/csv_to_popolo.rb
@@ -41,7 +41,7 @@ class Popolo
       type: 'link',
     },
     family_name: { 
-      aliases: %w(last_name),
+      aliases: %w(last_name surname),
       type: 'asis',
     },
     fax: { 
@@ -55,7 +55,7 @@ class Popolo
       type: 'asis',
     },
     given_name: { 
-      aliases: %w(first_name),
+      aliases: %w(first_name forename),
       type: 'asis',
     },
     group: { 

--- a/lib/csv_to_popolo.rb
+++ b/lib/csv_to_popolo.rb
@@ -25,6 +25,9 @@ class Popolo
       aliases: %w(mobile),
       type: 'contact',
     }, 
+    chamber: { 
+      aliases: %w(house),
+    },
     death_date: { 
       type: 'asis',
     },
@@ -167,7 +170,7 @@ class Popolo
     end
 
     def organizations
-      parties + legislatures + executive
+      parties + chambers + legislatures + executive
     end
 
     def memberships 
@@ -184,8 +187,17 @@ class Popolo
       end
     end
 
-    # For now, assume that we always have a legislature
-    # TODO cope with a file that *only* lists executive posts
+    def chambers 
+      # TODO the chambers should be members of the Legislature
+      @_chambers ||= @csv.find_all { |r| r.has_key? :chamber }.uniq { |r| r[:chamber] }.map do |r| 
+        {
+          id: r[:chamber_id] || "chamber/#{r[:chamber].downcase.gsub(/\s+/,'_')}",
+          name: r[:chamber],
+          classification: 'chamber',
+        }
+      end
+    end
+
     def legislatures
       legislative_memberships.count.zero? ? [] : [{
         id: 'legislature',
@@ -216,7 +228,7 @@ class Popolo
       @_lmems ||= @csv.find_all { |r| r.has_key? :group }.map do |r|
         mem = { 
           person_id:        r[:id],
-          organization_id:  'legislature',
+          organization_id:  find_chamber_id(r[:chamber]),
           role:             'member',
           start_date:       r[:start_date],
           end_date:         r[:end_date],
@@ -249,6 +261,10 @@ class Popolo
 
     def find_party_id(name)
       (parties.find { |p| p[:name] == name } or return)[:id]
+    end
+
+    def find_chamber_id(name='Legislature')
+      (chambers.find { |p| p[:name] == name } or return)[:id]
     end
 
 

--- a/lib/csv_to_popolo/version.rb
+++ b/lib/csv_to_popolo/version.rb
@@ -1,3 +1,3 @@
 module Popolo_CSV
-  VERSION = "0.7.3"
+  VERSION = "0.7.4"
 end

--- a/t/data/italy.csv
+++ b/t/data/italy.csv
@@ -1,0 +1,952 @@
+id,name,surname,party,area,house
+274886,AIELLO Pietro,AIELLO,Area Popolare (NCD-UDC),Calabria,Senate
+685864,Airola Alberto,Airola,Movimento 5 stelle,Piemonte,Senate
+341191,Albano Donatella,Albano,Partito Democratico,Liguria,Senate
+2,ALBERTINI Gabriele,ALBERTINI,Area Popolare (NCD-UDC),Lombardia,Senate
+332966,ALICATA Bruno,ALICATA,Popolo della Libertà,Sicilia,Senate
+1454,AMATI Silvana,AMATI,Partito Democratico,Marche,Senate
+8407,AMIDEI Bartolomeo,AMIDEI,Popolo della Libertà,Veneto,Senate
+175,AMORUSO Francesco Maria,AMORUSO,Popolo della Libertà,Puglia,Senate
+687154,Angioni Ignazio,Angioni,Partito Democratico,Sardegna,Senate
+687012,Anitori Fabiola,Anitori,Area Popolare (NCD-UDC),Lazio,Senate
+274860,ARACRI Francesco,ARACRI,Popolo della Libertà,Lazio,Senate
+9339,ARRIGONI Paolo,ARRIGONI,Lega Nord e autonomie,Lombardia,Senate
+124789,ASTORRE Bruno,ASTORRE,Partito Democratico,Lazio,Senate
+1460,AUGELLO Andrea,AUGELLO,Area Popolare (NCD-UDC),Lazio,Senate
+79566,AURICCHIO Domenico,AURICCHIO,Popolo della Libertà,Campania,Senate
+1461,AZZOLLINI Antonio,AZZOLLINI,Area Popolare (NCD-UDC),Puglia,Senate
+192,BARANI Lucio,BARANI,Grandi autonomie e libertà,Lombardia,Senate
+685753,Barozzino Giovanni,Barozzino,Gruppo Misto,Basilicata,Senate
+686927,Battista Lorenzo,Battista,Gruppo per le autonomie-Psi,Friuli-Venezia Giulia,Senate
+434820,Bellot Raffaela,Bellot,Lega Nord e autonomie,Veneto,Senate
+686973,Bencini Alessandra,Bencini,Gruppo Misto,Toscana,Senate
+6440,BERGER Johann Karl,BERGER,Gruppo per le autonomie-Psi,Trentino-Alto Adige,Senate
+332681,BERNINI Anna Maria,BERNINI,Popolo della Libertà,Emilia-Romagna,Senate
+330321,BERTACCO Stefano,BERTACCO,Popolo della Libertà,Veneto,Senate
+687122,Bertorotta Ornella,Bertorotta,Movimento 5 stelle,Sicilia,Senate
+240830,BERTUZZI Maria Teresa,BERTUZZI,Partito Democratico,Emilia-Romagna,Senate
+687124,Bianco Amedeo,Bianco,Partito Democratico,Sicilia,Senate
+1482,BIANCONI Laura,BIANCONI,Area Popolare (NCD-UDC),Emilia-Romagna,Senate
+686838,Bignami Laura,Bignami,Gruppo Misto,Lombardia,Senate
+121829,BILARDI Giovanni Emanuele,BILARDI,Area Popolare (NCD-UDC),Calabria,Senate
+570842,BISINELLA Patrizia,BISINELLA,Lega Nord e autonomie,Veneto,Senate
+685699,Blundo Rosetta Enza,Blundo,Movimento 5 stelle,Abruzzo,Senate
+687663,Bocca Bernabò,Bocca,Popolo della Libertà,Friuli-Venezia Giulia,Senate
+687126,Bocchino Fabrizio,Bocchino,Gruppo Misto,Sicilia,Senate
+225,BONAIUTI Paolo,BONAIUTI,Area Popolare (NCD-UDC),Lombardia,Senate
+226,BONDI Sandro,BONDI,Popolo della Libertà,Lombardia,Senate
+1490,BONFRISCO Anna Cinzia,BONFRISCO,Popolo della Libertà,Veneto,Senate
+4475,BORIOLI Daniele Gaetano,BORIOLI,Partito Democratico,Piemonte,Senate
+686975,Bottici Laura,Bottici,Movimento 5 stelle,Toscana,Senate
+27997,BROGLIA Claudio,BROGLIA,Partito Democratico,Emilia-Romagna,Senate
+7265,BRUNI Francesco,BRUNI,Popolo della Libertà,Puglia,Senate
+244,BRUNO Donato,BRUNO,Popolo della Libertà,Puglia,Senate
+1498,BUBBICO Filippo,BUBBICO,Partito Democratico,Basilicata,Senate
+687085,Buccarella Maurizio,Buccarella,Movimento 5 stelle,Puglia,Senate
+248,BUEMI Enrico,BUEMI,Gruppo per le autonomie-Psi,Piemonte,Senate
+686949,Bulgarelli Elisa,Bulgarelli,Movimento 5 stelle,Emilia-Romagna,Senate
+1506,CALDEROLI Roberto,CALDEROLI,Lega Nord e autonomie,Lombardia,Senate
+249123,CALEO Massimo,CALEO,Partito Democratico,Liguria,Senate
+333020,CALIENDO Giacomo,CALIENDO,Popolo della Libertà,Lombardia,Senate
+687128,Campanella Francesco,Campanella,Gruppo Misto,Sicilia,Senate
+170714,CANDIANI Stefano,CANDIANI,Lega Nord e autonomie,Lombardia,Senate
+241319,CANTINI Laura,CANTINI,Partito Democratico,Toscana,Senate
+685908,Capacchione Rosaria,Capacchione,Partito Democratico,Campania,Senate
+686907,Cappelletti Enrico,Cappelletti,Movimento 5 stelle,Veneto,Senate
+503343,CARDIELLO Franco,CARDIELLO,Popolo della Libertà,Campania,Senate
+497262,Cardinali Valeria,Cardinali,Partito Democratico,Umbria,Senate
+121854,CARIDI Antonio Stefano,CARIDI,Grandi autonomie e libertà,Calabria,Senate
+621567,CARRARO Franco,CARRARO,Popolo della Libertà,Emilia-Romagna,Senate
+686845,Casaletto Monica,Casaletto,Gruppo Misto,Lombardia,Senate
+278,CASINI Pier Ferdinando,CASINI,Area Popolare (NCD-UDC),Campania,Senate
+5092,CASSANO Massimo,CASSANO,Area Popolare (NCD-UDC),Puglia,Senate
+1516,CASSON Felice,CASSON,Partito Democratico,Veneto,Senate
+685702,Castaldi Gianluca,Castaldi,Movimento 5 stelle,Abruzzo,Senate
+687130,Catalfo Nunzia,Catalfo,Movimento 5 stelle,Sicilia,Senate
+708128,CATTANEO Elena,CATTANEO,Gruppo per le autonomie-Psi,"",Senate
+307538,Centinaio Gian Marco,Centinaio,Lega Nord e autonomie,Lombardia,Senate
+288,CERONI Remigio,CERONI,Popolo della Libertà,Marche,Senate
+8332,CERVELLINI Massimo,CERVELLINI,Gruppo Misto,Lazio,Senate
+388569,CHIAVAROLI Federica,CHIAVAROLI,Area Popolare (NCD-UDC),Abruzzo,Senate
+296,CHITI Vannino,CHITI,Partito Democratico,Piemonte,Senate
+1519,CIAMPI Carlo Azeglio,CIAMPI,Gruppo Misto,Senatore a vita,Senate
+687088,Ciampolillo Alfonso,Ciampolillo,Movimento 5 stelle,Puglia,Senate
+685955,Cioffi Andrea,Cioffi,Movimento 5 stelle,Campania,Senate
+125684,CIRINNA' Monica,CIRINNA',Partito Democratico,Lazio,Senate
+686848,Cociancich Roberto,Cociancich,Partito Democratico,Lombardia,Senate
+120703,Collina Stefano,Collina,Partito Democratico,Emilia-Romagna,Senate
+308,COLUCCI Francesco,COLUCCI,Area Popolare (NCD-UDC),Lombardia,Senate
+237135,COMAROLI Silvana,COMAROLI,Lega Nord e autonomie,Lombardia,Senate
+333052,COMPAGNA Luigi,COMPAGNA,Area Popolare (NCD-UDC),Campania,Senate
+288304,Compagnone Giuseppe,Compagnone,Grandi autonomie e libertà,Campania,Senate
+25231,CONSIGLIO Nunziante,CONSIGLIO,Lega Nord e autonomie,Lombardia,Senate
+166183,CONTE Franco,CONTE,Area Popolare (NCD-UDC),Veneto,Senate
+315,CONTI Riccardo,CONTI,Popolo della Libertà,Lombardia,Senate
+30950,CORSINI Paolo,CORSINI,Partito Democratico,Lombardia,Senate
+687156,Cotti Roberto,Cotti,Movimento 5 stelle,Sardegna,Senate
+494710,CRIMI Vito Claudio,CRIMI,Movimento 5 stelle,Lombardia,Senate
+8643,CROSIO Jonny,CROSIO,Lega Nord e autonomie,Lombardia,Senate
+364038,Cucca Giuseppe Luigi,Cucca,Partito Democratico,Sardegna,Senate
+79111,CUOMO Vincenzo,CUOMO,Partito Democratico,Campania,Senate
+169054,D'ADDA Erica,D'ADDA,Partito Democratico,Lombardia,Senate
+1537,D'ALI' Antonio,D'ALI',Popolo della Libertà,Sicilia,Senate
+333065,D'AMBROSIO LETTIERI Luigi,D'AMBROSIO LETTIERI,Popolo della Libertà,Puglia,Senate
+500781,D'ANNA Vincenzo,D'ANNA,Grandi autonomie e libertà,Campania,Senate
+685828,D'Ascola Vincenzo Mario Domenico,D'Ascola,Area Popolare (NCD-UDC),Calabria,Senate
+687091,D'Onghia Angela,D'Onghia,Grandi autonomie e libertà,Puglia,Senate
+8953,DALLA TOR Mario,DALLA TOR,Area Popolare (NCD-UDC),Veneto,Senate
+685760,Dalla Zuanna Gianpiero,Dalla Zuanna,Partito Democratico,Veneto,Senate
+1541,DAVICO Michelino,DAVICO,Grandi autonomie e libertà,Piemonte,Senate
+340,DE BIASI Emilia Grazia,DE BIASI,Partito Democratico,Lombardia,Senate
+344,DE CRISTOFARO Peppe,DE CRISTOFARO,Gruppo Misto,Campania,Senate
+1544,DE PETRIS Loredana,DE PETRIS,Gruppo Misto,Lazio,Senate
+686937,De Pietro Cristina,De Pietro,Gruppo Misto,Liguria,Senate
+685732,De Pin Paola,De Pin,Gruppo Misto,Veneto,Senate
+1545,DE POLI Antonio,DE POLI,Area Popolare (NCD-UDC),Veneto,Senate
+7629,DE SIANO Domenico,DE SIANO,Popolo della Libertà,Campania,Senate
+132852,DEL BARBA Mauro,DEL BARBA,Partito Democratico,Lombardia,Senate
+359,DELLA VEDOVA Benedetto,DELLA VEDOVA,Gruppo Misto,Lombardia,Senate
+332710,DI BIAGIO Aldo,DI BIAGIO,Area Popolare (NCD-UDC),Europa,Senate
+276824,Di Giacomo Ulisse,Di Giacomo,Area Popolare (NCD-UDC),Molise,Senate
+241490,DI GIORGI Rosa Maria,DI GIORGI,Partito Democratico,Toscana,Senate
+342242,Di Maggio Salvatore Tito,Di Maggio,Grandi autonomie e libertà,Basilicata,Senate
+275068,DIRINDIN Nerina,DIRINDIN,Partito Democratico,Piemonte,Senate
+1554,DIVINA Sergio,DIVINA,Lega Nord e autonomie,Trentino-Alto Adige,Senate
+687093,Donno Daniela,Donno,Movimento 5 stelle,Puglia,Senate
+685735,Endrizzi Giovanni,Endrizzi,Movimento 5 stelle,Veneto,Senate
+8760,ESPOSITO Stefano,ESPOSITO,Partito Democratico,Piemonte,Senate
+333101,ESPOSITO Giuseppe,ESPOSITO,Area Popolare (NCD-UDC),Campania,Senate
+687004,Fabbri Camilla,Fabbri,Partito Democratico,Marche,Senate
+602597,FALANGA Ciro,FALANGA,Popolo della Libertà,Campania,Senate
+333103,FASANO Vincenzo,FASANO,Popolo della Libertà,Campania,Senate
+721368,FASIOLO Laura,FASIOLO,Partito Democratico,Friuli-Venezia Giulia,Senate
+687019,Fattori Elena,Fattori,Movimento 5 stelle,Lazio,Senate
+685751,Fattorini Emma,Fattorini,Partito Democratico,Basilicata,Senate
+180261,FAVERO Nicoletta,FAVERO,Partito Democratico,Piemonte,Senate
+1562,FAZZONE Claudio,FAZZONE,Popolo della Libertà,Lazio,Senate
+686979,Fedeli Valeria,Fedeli,Partito Democratico,Toscana,Senate
+80512,FERRARA Elena,FERRARA,Partito Democratico,Piemonte,Senate
+1564,FERRARA Mario Francesco,FERRARA,Grandi autonomie e libertà,Sicilia,Senate
+1565,FILIPPI Marco,FILIPPI,Partito Democratico,Toscana,Senate
+418742,FILIPPIN Rosanna,FILIPPIN,Partito Democratico,Veneto,Senate
+1566,FINOCCHIARO Anna,FINOCCHIARO,Partito Democratico,Puglia,Senate
+158867,FISSORE Elena,FISSORE,Partito Democratico,Piemonte,Senate
+34366,FLORIS Emilio,FLORIS,Popolo della Libertà,Sardegna,Senate
+1572,FORMIGONI Roberto,FORMIGONI,Area Popolare (NCD-UDC),Lombardia,Senate
+14523,FORNARO Federico,FORNARO,Partito Democratico,Piemonte,Senate
+163021,FRAVEZZI Vittorio,FRAVEZZI,Gruppo per le autonomie-Psi,Trentino-Alto Adige,Senate
+687006,Fucksia Serenella,Fucksia,Movimento 5 stelle,Marche,Senate
+685944,Gaetti Luigi,Gaetti,Movimento 5 stelle,Lombardia,Senate
+686863,Galimberti Paolo,Galimberti,Popolo della Libertà,Lombardia,Senate
+686953,Gambaro Adele,Gambaro,Gruppo Misto,Emilia-Romagna,Senate
+446,GASPARRI Maurizio,GASPARRI,Popolo della Libertà,Lazio,Senate
+332724,GATTI Maria Grazia,GATTI,Partito Democratico,Toscana,Senate
+1586,GENTILE Antonio,GENTILE,Area Popolare (NCD-UDC),Calabria,Senate
+1587,GHEDINI Niccolo',GHEDINI,Popolo della Libertà,Veneto,Senate
+687171,Giacobbe Francesco,Giacobbe,Partito Democratico,Asia-Africa-Oceania-Antartide,Senate
+687668,Giannini Stefania,Giannini,Scelta civica per l'Italia,Toscana,Senate
+687134,Giarrusso Mario Michele,Giarrusso,Movimento 5 stelle,Sicilia,Senate
+332727,GIBIINO Vincenzo,GIBIINO,Popolo della Libertà,Sicilia,Senate
+88199,GINETTI Nadia,GINETTI,Partito Democratico,Umbria,Senate
+461,GIOVANARDI Carlo,GIOVANARDI,Area Popolare (NCD-UDC),Emilia-Romagna,Senate
+463,GIRO Francesco Maria,GIRO,Popolo della Libertà,Lazio,Senate
+686917,Girotto Gianni,Girotto,Movimento 5 stelle,Veneto,Senate
+686997,Gotor Miguel,Gotor,Partito Democratico,Umbria,Senate
+333147,GRANAIOLA Manuela,GRANAIOLA,Partito Democratico,Toscana,Senate
+687024,Grasso Pietro,Grasso,Partito Democratico,Lazio,Senate
+687667,Gualdani Marcello,Gualdani,Area Popolare (NCD-UDC),Sicilia,Senate
+622140,Guerra  Maria Cecilia,Guerra,Partito Democratico,Emilia-Romagna,Senate
+686939,Guerrieri Paleotti Paolo,Guerrieri Paleotti,Partito Democratico,Liguria,Senate
+333150,ICHINO Pietro,ICHINO,Scelta civica per l'Italia,Lombardia,Senate
+120828,IDEM Josefa,IDEM,Partito Democratico,Emilia-Romagna,Senate
+6542,IURLARO Pietro,IURLARO,Popolo della Libertà,Puglia,Senate
+275041,LAI Bachisio Silvio,LAI,Partito Democratico,Sardegna,Senate
+7621,LANGELLA Pietro,LANGELLA,Area Popolare (NCD-UDC),Campania,Senate
+368630,LANIECE Albert,LANIECE,Gruppo per le autonomie-Psi,Valle d'Aosta,Senate
+491,LANZILLOTTA Linda,LANZILLOTTA,Scelta civica per l'Italia,Umbria,Senate
+1603,LATORRE Nicola,LATORRE,Partito Democratico,Puglia,Senate
+4414,LEPRI Stefano,LEPRI,Partito Democratico,Piemonte,Senate
+687099,Lezzi Barbara,Lezzi,Movimento 5 stelle,Puglia,Senate
+22198,LIUZZI Pietro,LIUZZI,Popolo della Libertà,Puglia,Senate
+27631,LO GIUDICE Sergio,LO GIUDICE,Partito Democratico,Emilia-Romagna,Senate
+274922,LO MORO Doris,LO MORO,Partito Democratico,Calabria,Senate
+128480,LONGO Eva,LONGO,Popolo della Libertà,Campania,Senate
+687166,Longo Fausto Guilherme,Longo,Gruppo per le autonomie-Psi,America meridionale,Senate
+274873,LUCHERINI Carlo,LUCHERINI,Partito Democratico,Lazio,Senate
+687000,Lucidi Stefano,Lucidi,Movimento 5 stelle,Umbria,Senate
+521,LUMIA Giuseppe,LUMIA,Partito Democratico,Sicilia,Senate
+1619,MALAN Lucio,MALAN,Popolo della Libertà,Piemonte,Senate
+238486,MANASSERO Patrizia,MANASSERO,Partito Democratico,Piemonte,Senate
+274664,Manconi Luigi,Manconi,Partito Democratico,Sardegna,Senate
+74020,MANCUSO Bruno,MANCUSO,Area Popolare (NCD-UDC),Sicilia,Senate
+220838,MANDELLI Andrea,MANDELLI,Popolo della Libertà,Lombardia,Senate
+685945,Mangili Giovanna,Mangili,Movimento 5 stelle,Lombardia,Senate
+531,MARAN Alessandro,MARAN,Scelta civica per l'Italia,Friuli-Venezia Giulia,Senate
+274756,Marcucci Andrea,Marcucci,Partito Democratico,Toscana,Senate
+536,MARGIOTTA Salvatore,MARGIOTTA,Gruppo Misto,Basilicata,Senate
+82522,MARIN Marco,MARIN,Popolo della Libertà,Veneto,Senate
+538,MARINELLO Giuseppe Francesco Maria,MARINELLO,Area Popolare (NCD-UDC),Sicilia,Senate
+539,MARINO Mauro Maria,MARINO,Partito Democratico,Piemonte,Senate
+686960,Marino Luigi,Marino,Area Popolare (NCD-UDC),Emilia-Romagna,Senate
+685866,Martelli Carlo,Martelli,Movimento 5 stelle,Piemonte,Senate
+4769,MARTINI Claudio,MARTINI,Partito Democratico,Toscana,Senate
+686875,Marton Bruno,Marton,Movimento 5 stelle,Lombardia,Senate
+687027,Mastrangeli Marino Germano,Mastrangeli,Gruppo Misto,Lazio,Senate
+1639,MATTEOLI Altero,MATTEOLI,Popolo della Libertà,Toscana,Senate
+686987,Mattesini Donatella,Mattesini,Partito Democratico,Toscana,Senate
+8337,MATURANI Giuseppina,MATURANI,Partito Democratico,Lazio,Senate
+41,MAURO Mario,MAURO,Grandi autonomie e libertà,Lombardia,Senate
+1640,MAURO Giovanni,MAURO,Grandi autonomie e libertà,Campania,Senate
+332745,MAZZONI Riccardo,MAZZONI,Popolo della Libertà,Toscana,Senate
+561,MERLONI Maria Paola,MERLONI,Gruppo per le autonomie-Psi,Marche,Senate
+333195,MESSINA Alfredo,MESSINA,Popolo della Libertà,Lombardia,Senate
+1645,MICHELONI Claudio,MICHELONI,Partito Democratico,Europa,Senate
+564,MIGLIAVACCA Maurizio,MIGLIAVACCA,Partito Democratico,Emilia-Romagna,Senate
+5041,MILO Antonio,MILO,Grandi autonomie e libertà,Campania,Senate
+687140,Mineo Corradino,Mineo,Partito Democratico,Sicilia,Senate
+572,MINNITI Marco,MINNITI,Partito Democratico,Calabria,Senate
+687665,Minzolini Augusto,Minzolini,Popolo della Libertà,Liguria,Senate
+4540,MIRABELLI Franco,MIRABELLI,Partito Democratico,Lombardia,Senate
+685830,Molinari Francesco,Molinari,Gruppo Misto,Calabria,Senate
+686964,Montevecchi Michela,Montevecchi,Movimento 5 stelle,Emilia-Romagna,Senate
+617999,MONTI Mario,MONTI,Gruppo Misto,Senatore a vita,Senate
+504479,Morgoni Mario,Morgoni,Partito Democratico,Marche,Senate
+687068,Moronese Vilma,Moronese,Movimento 5 stelle,Campania,Senate
+685833,Morra Nicola,Morra,Movimento 5 stelle,Calabria,Senate
+249413,MOSCARDELLI Claudio,MOSCARDELLI,Partito Democratico,Lazio,Senate
+685948,Mucchetti Massimo,Mucchetti,Partito Democratico,Lombardia,Senate
+332759,MUNERATO Emanuela,MUNERATO,Lega Nord e autonomie,Veneto,Senate
+686966,Mussini Maria,Mussini,Gruppo Misto,Emilia-Romagna,Senate
+234249,NACCARATO Paolo,NACCARATO,Grandi autonomie e libertà,Lombardia,Senate
+1657,NAPOLITANO Giorgio,NAPOLITANO,Gruppo per le autonomie-Psi,"",Senate
+4836,NENCINI Riccardo,NENCINI,Gruppo per le autonomie-Psi,Marche,Senate
+685957,Nugnes Paola,Nugnes,Movimento 5 stelle,Campania,Senate
+685869,Olivero Andrea,Olivero,Gruppo per le autonomie-Psi,Piemonte,Senate
+686881,Orellana Luis Alberto,Orellana,Gruppo Misto,Lombardia,Senate
+687142,Orrù Pamela,Orrù,Partito Democratico,Sicilia,Senate
+8145,PADUA Venera,PADUA,Partito Democratico,Sicilia,Senate
+276974,Pagano Giuseppe,Pagano,Area Popolare (NCD-UDC),Sicilia,Senate
+346191,Pagliari Giorgio,Pagliari,Partito Democratico,Emilia-Romagna,Senate
+686989,Paglini Sara,Paglini,Movimento 5 stelle,Toscana,Senate
+4590,PAGNONCELLI Lionello Marco,PAGNONCELLI,Popolo della Libertà,Lombardia,Senate
+686897,Palermo Francesco,Palermo,Gruppo per le autonomie-Psi,Trentino-Alto Adige,Senate
+1667,PALMA Nitto Francesco,PALMA,Popolo della Libertà,Campania,Senate
+8852,PANIZZA Franco,PANIZZA,Gruppo per le autonomie-Psi,Trentino-Alto Adige,Senate
+637461,PARENTE Annamaria,PARENTE,Partito Democratico,Lazio,Senate
+1673,PEGORER Carlo,PEGORER,Partito Democratico,Friuli-Venezia Giulia,Senate
+630,PELINO Paola,PELINO,Popolo della Libertà,Abruzzo,Senate
+687073,Pepe Bartolomeo,Pepe,Gruppo Misto,Campania,Senate
+372722,Perrone Luigi,Perrone,Popolo della Libertà,Puglia,Senate
+4825,PETRAGLIA Alessia,PETRAGLIA,Gruppo Misto,Toscana,Senate
+685759,Petrocelli Vito,Petrocelli,Movimento 5 stelle,Basilicata,Senate
+7157,PEZZOPANE Stefania,PEZZOPANE,Partito Democratico,Abruzzo,Senate
+708130,PIANO Renzo,PIANO,Gruppo Misto,"",Senate
+415955,Piccinelli Enrico,Piccinelli,Popolo della Libertà,Lombardia,Senate
+23249,PICCOLI Giovanni,PICCOLI,Popolo della Libertà,Veneto,Senate
+1681,PIGNEDOLI Leana,PIGNEDOLI,Partito Democratico,Emilia-Romagna,Senate
+649,PINOTTI Roberta,PINOTTI,Partito Democratico,Liguria,Senate
+4546,PIZZETTI Luciano,PIZZETTI,Partito Democratico,Lombardia,Senate
+685954,Puglia Sergio,Puglia,Movimento 5 stelle,Campania,Senate
+430976,Puglisi Francesca,Puglisi,Partito Democratico,Emilia-Romagna,Senate
+165840,PUPPATO Laura,PUPPATO,Partito Democratico,Veneto,Senate
+276217,Quagliariello Gaetano,Quagliariello,Area Popolare (NCD-UDC),Abruzzo,Senate
+274877,RANUCCI Raffaele,RANUCCI,Partito Democratico,Lazio,Senate
+675,RAZZI Antonio,RAZZI,Popolo della Libertà,Abruzzo,Senate
+15141,REPETTI Manuela,REPETTI,Popolo della Libertà,Piemonte,Senate
+220625,RICCHIUTI Lucrezia,RICCHIUTI,Partito Democratico,Lombardia,Senate
+333257,RIZZOTTI Maria,RIZZOTTI,Popolo della Libertà,Piemonte,Senate
+685,ROMANI Paolo,ROMANI,Popolo della Libertà,Lombardia,Senate
+686992,Romani Maurizio,Romani,Gruppo Misto,Toscana,Senate
+685915,Romano Lucio,Romano,Gruppo per le autonomie-Psi,Campania,Senate
+686942,Rossi Maurizio Giuseppe,Rossi,Gruppo Misto,Liguria,Senate
+4868,ROSSI Gianluca,ROSSI,Partito Democratico,Umbria,Senate
+332896,ROSSI Mariarosaria,ROSSI,Popolo della Libertà,Lazio,Senate
+691,ROSSI Luciano,ROSSI,Area Popolare (NCD-UDC),Umbria,Senate
+708132,RUBBIA Carlo,RUBBIA,Gruppo per le autonomie-Psi,"",Senate
+686932,Russo Francesco,Russo,Partito Democratico,Friuli-Venezia Giulia,Senate
+701,RUTA Roberto,RUTA,Partito Democratico,Molise,Senate
+703,RUVOLO Giuseppe,RUVOLO,Grandi autonomie e libertà,Sicilia,Senate
+1712,SACCONI Maurizio,SACCONI,Area Popolare (NCD-UDC),Veneto,Senate
+128974,SAGGESE Angelica,SAGGESE,Partito Democratico,Campania,Senate
+333271,SANGALLI Gian Carlo,SANGALLI,Partito Democratico,Emilia-Romagna,Senate
+687147,Santangelo Vincenzo,Santangelo,Movimento 5 stelle,Sicilia,Senate
+685762,Santini Giorgio,Santini,Partito Democratico,Veneto,Senate
+7002,SCALIA Francesco,SCALIA,Partito Democratico,Lazio,Senate
+601464,SCAVONE Antonio Fabio Maria,SCAVONE,Grandi autonomie e libertà,Sicilia,Senate
+1723,SCHIFANI Renato Giuseppe,SCHIFANI,Area Popolare (NCD-UDC),Sicilia,Senate
+333282,SCIASCIA Salvatore,SCIASCIA,Popolo della Libertà,Lombardia,Senate
+685867,Scibona Marco,Scibona,Movimento 5 stelle,Piemonte,Senate
+332918,SCILIPOTI Domenico,SCILIPOTI,Popolo della Libertà,Calabria,Senate
+276853,Scoma Francesco,Scoma,Popolo della Libertà,Sicilia,Senate
+4551,SERAFINI Giancarlo,SERAFINI,Popolo della Libertà,Lombardia,Senate
+687161,Serra Manuela,Serra,Movimento 5 stelle,Sardegna,Senate
+5012,SIBILIA Cosimo,SIBILIA,Popolo della Libertà,Campania,Senate
+686888,Silvestro Annalisa,Silvestro,Partito Democratico,Lombardia,Senate
+687035,Simeoni Ivana,Simeoni,Gruppo Misto,Lazio,Senate
+78290,SOLLO Pasquale,SOLLO,Partito Democratico,Campania,Senate
+274815,Sonego Lodovico,Sonego,Partito Democratico,Friuli-Venezia Giulia,Senate
+645984,Spilabotte Maria,Spilabotte,Partito Democratico,Lazio,Senate
+732,SPOSETTI Ugo,SPOSETTI,Partito Democratico,Lazio,Senate
+533937,Stefani Erika,Stefani,Lega Nord e autonomie,Veneto,Senate
+5069,STEFANO Dario,STEFANO,Gruppo Misto,Puglia,Senate
+738,STUCCHI Giacomo,STUCCHI,Lega Nord e autonomie,Lombardia,Senate
+67,SUSTA Gianluca,SUSTA,Scelta civica per l'Italia,Piemonte,Senate
+5070,TARQUINIO Lucio Rosario,TARQUINIO,Popolo della Libertà,Puglia,Senate
+687039,Taverna Paola,Taverna,Movimento 5 stelle,Lazio,Senate
+748,TOCCI Walter,TOCCI,Partito Democratico,Lazio,Senate
+750,TOMASELLI Salvatore,TOMASELLI,Partito Democratico,Puglia,Senate
+1744,TONINI Giorgio,TONINI,Partito Democratico,Trentino-Alto Adige,Senate
+229570,TORRISI Salvo,TORRISI,Area Popolare (NCD-UDC),Sicilia,Senate
+174447,TOSATO Paolo,TOSATO,Lega Nord e autonomie,Veneto,Senate
+755,TREMONTI Giulio,TREMONTI,Grandi autonomie e libertà,Piemonte,Senate
+607001,TRONTI Mario,TRONTI,Partito Democratico,Lombardia,Senate
+1748,TURANO Renato Guerino,TURANO,Partito Democratico,America settentrionale e centrale,Senate
+275038,URAS Luciano,URAS,Gruppo Misto,Sardegna,Senate
+7579,VACCARI Stefano,VACCARI,Partito Democratico,Emilia-Romagna,Senate
+687042,Vacciano Giuseppe,Vacciano,Gruppo Misto,Lazio,Senate
+728635,VALDINOSI Mara,VALDINOSI,Partito Democratico,Emilia-Romagna,Senate
+274824,VALENTINI Daniela,VALENTINI,Partito Democratico,Lazio,Senate
+686944,Vattuone Vito,Vattuone,Partito Democratico,Liguria,Senate
+772,VERDINI Denis,VERDINI,Popolo della Libertà,Toscana,Senate
+655704,VERDUCCI Francesco,VERDUCCI,Partito Democratico,Marche,Senate
+83884,VICARI Simona,VICARI,Area Popolare (NCD-UDC),Sicilia,Senate
+1758,VICECONTE Guido Walter Cesare,VICECONTE,Area Popolare (NCD-UDC),Basilicata,Senate
+778,VILLARI Riccardo,VILLARI,Popolo della Libertà,Campania,Senate
+332950,VOLPI Raffaele,VOLPI,Lega Nord e autonomie,Lombardia,Senate
+1764,ZANDA Luigi,ZANDA,Partito Democratico,Lazio,Senate
+159404,ZANONI Magda Angela,ZANONI,Partito Democratico,Piemonte,Senate
+1767,ZAVOLI Sergio,ZAVOLI,Partito Democratico,Campania,Senate
+795,ZELLER Karl,ZELLER,Gruppo per le autonomie-Psi,Trentino-Alto Adige,Senate
+687168,Zin Claudio,Zin,Gruppo per le autonomie-Psi,America meridionale,Senate
+286531,Zizza Vittorio,Zizza,Popolo della Libertà,Puglia,Senate
+4577,ZUFFADA Sante,ZUFFADA,Popolo della Libertà,Lombardia,Senate
+332669,ABRIGNANI Ignazio,ABRIGNANI,Popolo della Libertà,Marche,Chamber of Deputies
+161,ADORNATO Ferdinando,ADORNATO,Area Popolare (NCD-UDC),Sicilia 1,Chamber of Deputies
+686429,Agostinelli Donatella,Agostinelli,Movimento 5 stelle,Marche,Chamber of Deputies
+8364,AGOSTINI Roberta,AGOSTINI,Partito Democratico,Campania 1,Chamber of Deputies
+4876,AGOSTINI Luciano,AGOSTINI,Partito Democratico,Marche,Chamber of Deputies
+277140,Aiello Ferdinando,Aiello,Partito Democratico,Calabria,Chamber of Deputies
+685919,Airaudo Giorgio,Airaudo,Sinistra ecologia e libertà,Piemonte 1,Chamber of Deputies
+686654,Albanella Luisella,Albanella,Partito Democratico,Sicilia 2,Chamber of Deputies
+686381,Alberti Dino,Alberti,Movimento 5 stelle,Lombardia 2,Chamber of Deputies
+241529,ALBINI Tea,ALBINI,Partito Democratico,Toscana,Chamber of Deputies
+169,ALFANO Gioacchino,ALFANO,Area Popolare (NCD-UDC),Campania 1,Chamber of Deputies
+167,ALFANO Angelino,ALFANO,Area Popolare (NCD-UDC),Piemonte 1,Chamber of Deputies
+508028,Alfreider Daniel,Alfreider,Gruppo Misto,Trentino-Alto Adige,Chamber of Deputies
+171,ALLASIA Stefano,ALLASIA,Lega Nord e autonomie,Piemonte 1,Chamber of Deputies
+500293,ALLI Paolo,ALLI,Area Popolare (NCD-UDC),Lombardia 3,Chamber of Deputies
+6261,ALTIERI Trifone,ALTIERI,Popolo della Libertà,Puglia,Chamber of Deputies
+629710,AMATO Maria,AMATO,Partito Democratico,Abruzzo,Chamber of Deputies
+685991,Amendola Vincenzo,Amendola,Partito Democratico,Campania 2,Chamber of Deputies
+174,AMICI Sesa,AMICI,Partito Democratico,Lazio 2,Chamber of Deputies
+687662,Amoddio Sofia,Amoddio,Partito Democratico,Sicilia 2,Chamber of Deputies
+332670,ANGELUCCI Antonio,ANGELUCCI,Popolo della Libertà,Lombardia 2,Chamber of Deputies
+5146,ANTEZZA Maria,ANTEZZA,Partito Democratico,Basilicata,Chamber of Deputies
+686224,Anzaldi Michele,Anzaldi,Partito Democratico,Emilia-Romagna,Chamber of Deputies
+687659,Archi Bruno,Archi,Popolo della Libertà,Piemonte 2,Chamber of Deputies
+125726,ARGENTIN Ileana,ARGENTIN,Partito Democratico,Lazio 1,Chamber of Deputies
+324652,Arlotti Tiziano,Arlotti,Partito Democratico,Emilia-Romagna,Chamber of Deputies
+686708,Artini Massimo,Artini,Gruppo Misto,Toscana,Chamber of Deputies
+686730,Ascani Anna,Ascani,Partito Democratico,Umbria,Chamber of Deputies
+686140,Attaguile Angelo,Attaguile,Lega Nord e autonomie,Campania 2,Chamber of Deputies
+686710,Baldassarre Marco,Baldassarre,Gruppo Misto,Toscana,Chamber of Deputies
+189,BALDELLI Simone,BALDELLI,Popolo della Libertà,Marche,Chamber of Deputies
+685793,Barbanti Sebastiano,Barbanti,Gruppo Misto,Calabria,Chamber of Deputies
+332675,BARETTA Pier Paolo,BARETTA,Partito Democratico,Veneto 2,Chamber of Deputies
+14400,BARGERO Cristina,BARGERO,Partito Democratico,Piemonte 2,Chamber of Deputies
+687336,Baroni Massimo Enrico,Baroni,Movimento 5 stelle,Lazio 1,Chamber of Deputies
+77900,BARUFFI Davide,BARUFFI,Partito Democratico,Emilia-Romagna,Chamber of Deputies
+685987,Basilio Tatiana,Basilio,Movimento 5 stelle,Lombardia 2,Chamber of Deputies
+403281,Basso Lorenzo,Basso,Partito Democratico,Liguria,Chamber of Deputies
+8249,BATTAGLIA Demetrio,BATTAGLIA,Partito Democratico,Calabria,Chamber of Deputies
+686281,Battelli Sergio,Battelli,Movimento 5 stelle,Liguria,Chamber of Deputies
+557459,Bazoli Alfredo,Bazoli,Partito Democratico,Lombardia 2,Chamber of Deputies
+721559,BECATTINI Lorenzo,BECATTINI,Partito Democratico,Toscana,Chamber of Deputies
+685930,Bechis Eleonora,Bechis,Gruppo Misto,Piemonte 1,Chamber of Deputies
+197,BELLANOVA Teresa,BELLANOVA,Partito Democratico,Puglia,Chamber of Deputies
+332677,BENAMATI Gianluca,BENAMATI,Partito Democratico,Piemonte 1,Chamber of Deputies
+685849,Benedetti Silvia,Benedetti,Movimento 5 stelle,Veneto 1,Chamber of Deputies
+686691,Beni Paolo,Beni,Partito Democratico,Toscana,Chamber of Deputies
+332679,BERGAMINI Deborah,BERGAMINI,Popolo della Libertà,Emilia-Romagna,Chamber of Deputies
+501411,Bergonzi Marco,Bergonzi,Partito Democratico,Emilia-Romagna,Chamber of Deputies
+517174,Berlinghieri Marina,Berlinghieri,Partito Democratico,Lombardia 2,Chamber of Deputies
+205,BERNARDO Maurizio,BERNARDO,Area Popolare (NCD-UDC),Lombardia 1,Chamber of Deputies
+686238,Bernini Paolo,Bernini,Movimento 5 stelle,Emilia-Romagna,Chamber of Deputies
+687353,Bernini Massimiliano,Bernini,Movimento 5 stelle,Lazio 2,Chamber of Deputies
+229196,BERRETTA Giuseppe,BERRETTA,Partito Democratico,Sicilia 2,Chamber of Deputies
+207,BERSANI Pier Luigi,BERSANI,Partito Democratico,Lombardia 1,Chamber of Deputies
+213,BIANCHI Dorina,BIANCHI,Area Popolare (NCD-UDC),Calabria,Chamber of Deputies
+686419,Bianchi Mariastella,Bianchi,Partito Democratico,Marche,Chamber of Deputies
+687580,Bianchi Nicola,Bianchi,Movimento 5 stelle,Sardegna,Chamber of Deputies
+215,BIANCOFIORE Michaela,BIANCOFIORE,Popolo della Libertà,Trentino-Alto Adige,Chamber of Deputies
+4787,BIANCONI Maurizio,BIANCONI,Popolo della Libertà,Toscana,Chamber of Deputies
+4670,BIASOTTI Sandro,BIASOTTI,Popolo della Libertà,Liguria,Chamber of Deputies
+217,BINDI Rosy,BINDI,Partito Democratico,Calabria,Chamber of Deputies
+1483,BINETTI Paola,BINETTI,Area Popolare (NCD-UDC),Lazio 1,Chamber of Deputies
+4788,BINI Caterina,BINI,Partito Democratico,Toscana,Chamber of Deputies
+332997,BIONDELLI Franca Maria Grazia,BIONDELLI,Partito Democratico,Piemonte 2,Chamber of Deputies
+274772,BLAZINA Tamara,BLAZINA,Partito Democratico,Friuli-Venezia Giulia,Chamber of Deputies
+1485,BOBBA Luigi,BOBBA,Partito Democratico,Piemonte 2,Chamber of Deputies
+686793,Boccadutri Sergio,Boccadutri,Partito Democratico,Lazio 1,Chamber of Deputies
+220,BOCCI Gianpiero,BOCCI,Partito Democratico,Umbria,Chamber of Deputies
+332683,BOCCIA Francesco,BOCCIA,Partito Democratico,Puglia,Chamber of Deputies
+332684,BOCCUZZI Antonio,BOCCUZZI,Partito Democratico,Piemonte 1,Chamber of Deputies
+686427,Boldrini Laura,Boldrini,Sinistra ecologia e libertà,Sicilia 2,Chamber of Deputies
+753399,BOLDRINI Paola,BOLDRINI,Partito Democratico,Emilia-Romagna,Chamber of Deputies
+686220,Bolognesi Paolo,Bolognesi,Partito Democratico,Emilia-Romagna,Chamber of Deputies
+685969,Bombassei Alberto,Bombassei,Scelta civica per l'Italia,Lombardia 2,Chamber of Deputies
+686782,Bonaccorsi Lorenza,Bonaccorsi,Partito Democratico,Lazio 1,Chamber of Deputies
+686706,Bonafede Alfonso,Bonafede,Movimento 5 stelle,Toscana,Chamber of Deputies
+332685,BONAVITACOLA Fulvio,BONAVITACOLA,Partito Democratico,Campania 2,Chamber of Deputies
+497442,Bonifazi Francesco,Bonifazi,Partito Democratico,Piemonte 2,Chamber of Deputies
+437762,Bonomo Francesca,Bonomo,Partito Democratico,Piemonte 1,Chamber of Deputies
+232,BORDO Michele,BORDO,Partito Democratico,Puglia,Chamber of Deputies
+236257,BORDO Franco,BORDO,Sinistra ecologia e libertà,Lombardia 3,Chamber of Deputies
+687583,Borghese Mario,Borghese,Gruppo Misto,America meridionale,Chamber of Deputies
+420242,Borghesi Stefano,Borghesi,Lega Nord e autonomie,Lombardia 2,Chamber of Deputies
+219411,BORGHI Enrico,BORGHI,Partito Democratico,Piemonte 2,Chamber of Deputies
+686340,Borletti Buitoni Ilaria,Borletti Buitoni,Scelta civica per l'Italia,Lombardia 1,Chamber of Deputies
+686698,Boschi Maria Elena,Boschi,Partito Democratico,Toscana,Chamber of Deputies
+357920,Bosco Antonino,Bosco,Area Popolare (NCD-UDC),Sicilia 1,Chamber of Deputies
+5005,BOSSA Luisa,BOSSA,Partito Democratico,Campania 1,Chamber of Deputies
+12,BOSSI Umberto,BOSSI,Lega Nord e autonomie,Lombardia 2,Chamber of Deputies
+232683,BRAGA Chiara,BRAGA,Partito Democratico,Lombardia 2,Chamber of Deputies
+9048,BRAGANTINI Matteo,BRAGANTINI,Lega Nord e autonomie,Veneto 1,Chamber of Deputies
+685910,Bragantini Paola,Bragantini,Partito Democratico,Piemonte 1,Chamber of Deputies
+332687,BRAMBILLA Michela Vittoria,BRAMBILLA,Popolo della Libertà,Emilia-Romagna,Chamber of Deputies
+383352,Brandolin Giorgio,Brandolin,Partito Democratico,Friuli-Venezia Giulia,Chamber of Deputies
+240904,BRATTI Alessandro,BRATTI,Partito Democratico,Emilia-Romagna,Chamber of Deputies
+686441,Bray Massimo,Bray,Partito Democratico,Puglia,Chamber of Deputies
+686473,Brescia Giuseppe,Brescia,Movimento 5 stelle,Puglia,Chamber of Deputies
+239,BRESSA Gianclaudio,BRESSA,Partito Democratico,Trentino-Alto Adige,Chamber of Deputies
+687295,Brugnerotto Marco,Brugnerotto,Movimento 5 stelle,Veneto 1,Chamber of Deputies
+14,BRUNETTA Renato,BRUNETTA,Popolo della Libertà,Veneto 2,Chamber of Deputies
+1495,BRUNO Franco,BRUNO,Gruppo Misto,Calabria,Chamber of Deputies
+685783,Bruno Bossio Enza,Bruno Bossio,Partito Democratico,Calabria,Chamber of Deputies
+687586,Bueno Renata,Bueno,Gruppo Misto,America meridionale,Chamber of Deputies
+255,BURTONE Giovanni Mario Salvino,BURTONE,Partito Democratico,Sicilia 2,Chamber of Deputies
+176599,BUSIN Filippo,BUSIN,Lega Nord e autonomie,Veneto 1,Chamber of Deputies
+687291,Businarolo Francesca,Businarolo,Movimento 5 stelle,Veneto 1,Chamber of Deputies
+685875,Busto Mirko,Busto,Movimento 5 stelle,Piemonte 2,Chamber of Deputies
+1503,BUTTIGLIONE Rocco,BUTTIGLIONE,Area Popolare (NCD-UDC),Campania 1,Chamber of Deputies
+356761,CALABRIA Annagrazia,CALABRIA,Popolo della Libertà,Piemonte 1,Chamber of Deputies
+333017,CALABRO' Raffaele,CALABRO',Area Popolare (NCD-UDC),Campania 1,Chamber of Deputies
+305588,Camani Vanessa,Camani,Partito Democratico,Veneto 1,Chamber of Deputies
+686768,Campana Micaela,Campana,Partito Democratico,Lazio 1,Chamber of Deputies
+686537,Cancelleri Azzurra,Cancelleri,Movimento 5 stelle,Sicilia 1,Chamber of Deputies
+9514,CANI Emanuele,CANI,Partito Democratico,Sardegna,Chamber of Deputies
+345364,Caon Roberto,Caon,Lega Nord e autonomie,Veneto 1,Chamber of Deputies
+264,CAPARINI Davide,CAPARINI,Lega Nord e autonomie,Lombardia 2,Chamber of Deputies
+81211,CAPELLI Roberto,CAPELLI,Per L'Italia,Sardegna,Chamber of Deputies
+265,CAPEZZONE Daniele,CAPEZZONE,Popolo della Libertà,Piemonte 1,Chamber of Deputies
+267,CAPODICASA Angelo,CAPODICASA,Partito Democratico,Sicilia 1,Chamber of Deputies
+7298,CAPONE Salvatore,CAPONE,Partito Democratico,Puglia,Chamber of Deputies
+686158,Capozzolo Sabrina,Capozzolo,Partito Democratico,Campania 2,Chamber of Deputies
+685853,Capua Ilaria,Capua,Scelta civica per l'Italia,Veneto 1,Chamber of Deputies
+686313,Carbone Ernesto,Carbone,Partito Democratico,Lombardia 1,Chamber of Deputies
+332695,CARDINALE Daniela,CARDINALE,Partito Democratico,Sicilia 1,Chamber of Deputies
+313306,Carella Renzo,Carella,Partito Democratico,Lazio 1,Chamber of Deputies
+272,CARFAGNA Maria Rosaria,CARFAGNA,Popolo della Libertà,Campania 2,Chamber of Deputies
+686479,Cariello Francesco,Cariello,Movimento 5 stelle,Puglia,Chamber of Deputies
+686328,Carinelli Paola,Carinelli,Movimento 5 stelle,Lombardia 1,Chamber of Deputies
+1512,CARLONI Anna Maria,CARLONI,Partito Democratico,Campania 1,Chamber of Deputies
+24626,CARNEVALI Elena,CARNEVALI,Partito Democratico,Lombardia 2,Chamber of Deputies
+686273,Carocci Mara,Carocci,Partito Democratico,Liguria,Chamber of Deputies
+332698,CARRA Marco,CARRA,Partito Democratico,Lombardia 3,Chamber of Deputies
+686423,Carrescia Piergiorgio,Carrescia,Partito Democratico,Marche,Chamber of Deputies
+686674,Carrozza Maria Chiara,Carrozza,Partito Democratico,Toscana,Chamber of Deputies
+687590,Caruso Mario,Caruso,Per L'Italia,Europa,Chamber of Deputies
+7545,CASATI Ezio Primo,CASATI,Partito Democratico,Lombardia 1,Chamber of Deputies
+165773,CASELLATO Floriana,CASELLATO,Partito Democratico,Veneto 2,Chamber of Deputies
+277,CASERO Luigi,CASERO,Area Popolare (NCD-UDC),Lombardia 1,Chamber of Deputies
+686332,Caso Vincenzo,Caso,Movimento 5 stelle,Lombardia 1,Chamber of Deputies
+686438,Cassano Franco,Cassano,Partito Democratico,Puglia,Chamber of Deputies
+685925,Castelli Laura,Castelli,Movimento 5 stelle,Piemonte 1,Chamber of Deputies
+282,CASTIELLO Giuseppina,CASTIELLO,Popolo della Libertà,Campania 1,Chamber of Deputies
+17,CASTIGLIONE Giuseppe,CASTIGLIONE,Area Popolare (NCD-UDC),Sicilia 2,Chamber of Deputies
+7996,CASTRICONE Antonio,CASTRICONE,Partito Democratico,Abruzzo,Chamber of Deputies
+686387,Catalano Ivan,Catalano,Gruppo Misto,Lombardia 2,Chamber of Deputies
+618125,Catania Mario,Catania,Scelta civica per l'Italia,Veneto 1,Chamber of Deputies
+283,CATANOSO Basilio,CATANOSO,Popolo della Libertà,Sicilia 2,Chamber of Deputies
+276597,Causi Marco,Causi,Partito Democratico,Sicilia 1,Chamber of Deputies
+4623,CAUSIN Andrea,CAUSIN,Area Popolare (NCD-UDC),Veneto 2,Chamber of Deputies
+686431,Cecconi Andrea,Cecconi,Movimento 5 stelle,Marche,Chamber of Deputies
+4842,CENNI Susanna,CENNI,Partito Democratico,Toscana,Chamber of Deputies
+219951,CENSORE Bruno,CENSORE,Partito Democratico,Calabria,Chamber of Deputies
+332701,CENTEMERO Elena,CENTEMERO,Popolo della Libertà,Lombardia 1,Chamber of Deputies
+5086,CERA Angelo,CERA,Area Popolare (NCD-UDC),Puglia,Chamber of Deputies
+291,CESARO Luigi,CESARO,Popolo della Libertà,Campania 1,Chamber of Deputies
+685993,Cesaro Antimo,Cesaro,Scelta civica per l'Italia,Campania 2,Chamber of Deputies
+687643,Chaouki Khalid,Chaouki,Partito Democratico,Campania 2,Chamber of Deputies
+5078,CHIARELLI Gianfranco,CHIARELLI,Popolo della Libertà,Puglia,Chamber of Deputies
+685927,Chimienti Silvia,Chimienti,Movimento 5 stelle,Piemonte 1,Chamber of Deputies
+298,CICCHITTO Fabrizio,CICCHITTO,Area Popolare (NCD-UDC),Lazio 1,Chamber of Deputies
+501219,Cimbro Eleonora,Cimbro,Partito Democratico,Lombardia 1,Chamber of Deputies
+685886,Cimmino Luciano,Cimmino,Scelta civica per l'Italia,Campania 1,Chamber of Deputies
+686733,Ciprini Tiziana,Ciprini,Movimento 5 stelle,Umbria,Chamber of Deputies
+6524,CIRACI' Nicola,CIRACI',Popolo della Libertà,Puglia,Chamber of Deputies
+303,CIRIELLI Edmondo,CIRIELLI,Fratelli d'Italia - Centrodestra Nazionale,Campania 2,Chamber of Deputies
+4537,CIVATI Giuseppe,CIVATI,Partito Democratico,Lombardia 1,Chamber of Deputies
+686148,Coccia Laura,Coccia,Partito Democratico,Campania 2,Chamber of Deputies
+332703,COLANINNO Matteo,COLANINNO,Partito Democratico,Lombardia 3,Chamber of Deputies
+685684,Colletti Andrea,Colletti,Movimento 5 stelle,Abruzzo,Chamber of Deputies
+686131,Colonnese Vega,Colonnese,Movimento 5 stelle,Campania 1,Chamber of Deputies
+685984,COMINARDI Claudio,COMINARDI,Movimento 5 stelle,Lombardia 2,Chamber of Deputies
+685961,Cominelli Miriam,Cominelli,Partito Democratico,Lombardia 2,Chamber of Deputies
+356940,COPPOLA Paolo,COPPOLA,Partito Democratico,Friuli-Venezia Giulia,Chamber of Deputies
+686505,Corda Emanuela,Corda,Movimento 5 stelle,Sardegna,Chamber of Deputies
+4518,CORSARO Massimo,CORSARO,Gruppo Misto,Lombardia 1,Chamber of Deputies
+313965,Coscia Maria,Coscia,Partito Democratico,Lazio 1,Chamber of Deputies
+321,COSTA Enrico,COSTA,Area Popolare (NCD-UDC),Piemonte 2,Chamber of Deputies
+687375,Costantino Celestina,Costantino,Sinistra ecologia e libertà,Piemonte 1,Chamber of Deputies
+495096,Cova Paolo,Cova,Partito Democratico,Lombardia 1,Chamber of Deputies
+494722,Covello Stefania,Covello,Partito Democratico,Calabria,Chamber of Deputies
+687320,Cozzolino Emanuele,Cozzolino,Movimento 5 stelle,Veneto 2,Chamber of Deputies
+687261,Crimì Filippo,Crimì,Partito Democratico,Veneto 1,Chamber of Deputies
+326,CRIMI Rocco,CRIMI,Popolo della Libertà,Lazio 2,Chamber of Deputies
+685876,Crippa Davide,Crippa,Movimento 5 stelle,Piemonte 2,Chamber of Deputies
+126707,CRIVELLARI Diego,CRIVELLARI,Partito Democratico,Veneto 1,Chamber of Deputies
+504322,CULOTTA Magda,CULOTTA,Partito Democratico,Sicilia 1,Chamber of Deputies
+330,CUPERLO Giovanni,CUPERLO,Partito Democratico,Lazio 1,Chamber of Deputies
+686660,Currò Tommaso,Currò,Gruppo Misto,Sicilia 2,Chamber of Deputies
+685996,D'Agostino Angelo,D'Agostino,Scelta civica per l'Italia,Campania 2,Chamber of Deputies
+617979,D'ALESSANDRO Luca,D'ALESSANDRO,Popolo della Libertà,Campania 2,Chamber of Deputies
+333,D'ALIA Gianpiero,D'ALIA,Area Popolare (NCD-UDC),Sicilia 1,Chamber of Deputies
+686467,D'Ambrosio Giuseppe,D'Ambrosio,Movimento 5 stelle,Puglia,Chamber of Deputies
+9010,D'ARIENZO Vincenzo,D'ARIENZO,Partito Democratico,Veneto 1,Chamber of Deputies
+685781,D'Attorre Alfredo,D'Attorre,Partito Democratico,Calabria,Chamber of Deputies
+685802,D'Incà Federico,D'Incà,Movimento 5 stelle,Veneto 2,Chamber of Deputies
+90393,D'INCECCO Vittoria,D'INCECCO,Partito Democratico,Abruzzo,Chamber of Deputies
+8807,D'OTTAVIO Umberto,D'OTTAVIO,Partito Democratico,Piemonte 1,Chamber of Deputies
+686666,D'Uva Francesco,D'Uva,Movimento 5 stelle,Sicilia 2,Chamber of Deputies
+685807,Da Villa Marco,Da Villa,Movimento 5 stelle,Veneto 2,Chamber of Deputies
+685877,Dadone Fabiana,Dadone,Movimento 5 stelle,Piemonte 2,Chamber of Deputies
+687322,Daga Federica,Daga,Movimento 5 stelle,Lazio 1,Chamber of Deputies
+332705,DAL MORO Gian Pietro,DAL MORO,Partito Democratico,Veneto 1,Chamber of Deputies
+686047,Dall'Osso Matteo,Dall'Osso,Movimento 5 stelle,Emilia-Romagna,Chamber of Deputies
+686695,Dallai Luigi,Dallai,Partito Democratico,Toscana,Chamber of Deputies
+686342,Dambruoso Stefano,Dambruoso,Scelta civica per l'Italia,Lombardia 1,Chamber of Deputies
+335,DAMIANO Cesare,DAMIANO,Partito Democratico,Piemonte 1,Chamber of Deputies
+332706,DE GIROLAMO Nunzia,DE GIROLAMO,Area Popolare (NCD-UDC),Campania 2,Chamber of Deputies
+686471,De Lorenzis Diego,De Lorenzis,Movimento 5 stelle,Puglia,Chamber of Deputies
+6429,DE MARIA Andrea,DE MARIA,Partito Democratico,Emilia-Romagna,Chamber of Deputies
+23078,DE MENECH Roger,DE MENECH,Partito Democratico,Veneto 2,Chamber of Deputies
+332707,DE MICHELI Paola,DE MICHELI,Partito Democratico,Emilia-Romagna,Chamber of Deputies
+6211,DE MITA Giuseppe,DE MITA,Area Popolare (NCD-UDC),Campania 2,Chamber of Deputies
+686330,De Rosa Massimo,De Rosa,Movimento 5 stelle,Lombardia 1,Chamber of Deputies
+499559,DEL BASSO DE CARO Umberto,DEL BASSO DE CARO,Partito Democratico,Campania 2,Chamber of Deputies
+685685,Del Grosso Daniele,Del Grosso,Movimento 5 stelle,Abruzzo,Chamber of Deputies
+685959,Dell'Aringa Carlo,Dell'Aringa,Partito Democratico,Lombardia 2,Chamber of Deputies
+686240,Dell'Orco Michele,Dell'Orco,Movimento 5 stelle,Emilia-Romagna,Chamber of Deputies
+476784,Della Valle Ivan,Della Valle,Movimento 5 stelle,Piemonte 1,Chamber of Deputies
+8815,DELLAI Lorenzo,DELLAI,Per L'Italia,Trentino-Alto Adige,Chamber of Deputies
+687328,Di Battista Alessandro,Di Battista,Movimento 5 stelle,Lazio 1,Chamber of Deputies
+686533,Di Benedetto Chiara,Di Benedetto,Movimento 5 stelle,Sicilia 1,Chamber of Deputies
+364,DI GIOIA Raffaele,DI GIOIA,Gruppo Misto,Sardegna,Chamber of Deputies
+5059,DI LELLO Marco,DI LELLO,Gruppo Misto,Campania 1,Chamber of Deputies
+685892,Di Maio Luigi,Di Maio,Movimento 5 stelle,Campania 1,Chamber of Deputies
+429177,Di Maio Marco,Di Maio,Partito Democratico,Emilia-Romagna,Chamber of Deputies
+368,DI SALVO Titti,DI SALVO,Partito Democratico,Lombardia 2,Chamber of Deputies
+686334,Di Stefano Manlio,Di Stefano,Movimento 5 stelle,Lombardia 1,Chamber of Deputies
+4958,DI STEFANO Fabrizio,DI STEFANO,Popolo della Libertà,Abruzzo,Chamber of Deputies
+274823,DI STEFANO Marco,DI STEFANO,Partito Democratico,Lazio 1,Chamber of Deputies
+686531,Di Vita Giulia,Di Vita,Movimento 5 stelle,Sicilia 1,Chamber of Deputies
+685794,Dieni Federica,Dieni,Movimento 5 stelle,Calabria,Chamber of Deputies
+332713,DISTASO Antonio,DISTASO,Popolo della Libertà,Puglia,Chamber of Deputies
+17508,DONATI Marco,DONATI,Partito Democratico,Toscana,Chamber of Deputies
+380,DURANTI Donatella,DURANTI,Sinistra ecologia e libertà,Puglia,Chamber of Deputies
+685884,Epifani Ettore Guglielmo,Epifani,Partito Democratico,Campania 1,Chamber of Deputies
+6887,ERMINI David,ERMINI,Partito Democratico,Toscana,Chamber of Deputies
+28635,FABBRI Marilena,FABBRI,Partito Democratico,Emilia-Romagna,Chamber of Deputies
+246108,FAENZI Monica,FAENZI,Popolo della Libertà,Toscana,Chamber of Deputies
+685891,FALCONE Giovanni,FALCONE,Scelta civica per l'Italia,Piemonte 2,Chamber of Deputies
+20720,FAMIGLIETTI Luigi,FAMIGLIETTI,Partito Democratico,Campania 2,Chamber of Deputies
+687297,Fantinati Mattia,Fantinati,Movimento 5 stelle,Veneto 1,Chamber of Deputies
+118748,FANUCCI Edoardo,FANUCCI,Partito Democratico,Toscana,Chamber of Deputies
+84423,FARAONE Davide,FARAONE,Partito Democratico,Sicilia 1,Chamber of Deputies
+388,FARINA Daniele,FARINA,Sinistra ecologia e libertà,Lombardia 1,Chamber of Deputies
+389,FARINA Gianni,FARINA,Partito Democratico,Europa,Chamber of Deputies
+686763,Fassina Stefano,Fassina,Partito Democratico,Lazio 1,Chamber of Deputies
+687359,FAUTTILLI Federico,FAUTTILLI,Per L'Italia,Lazio 2,Chamber of Deputies
+26,FAVA Claudio,FAVA,Gruppo Misto,Lombardia 1,Chamber of Deputies
+396,FEDI Marco,FEDI,Partito Democratico,Asia-Africa-Oceania-Antartide,Chamber of Deputies
+332717,FEDRIGA Massimiliano,FEDRIGA,Lega Nord e autonomie,Friuli-Venezia Giulia,Chamber of Deputies
+332718,FERRANTI Donatella,FERRANTI,Partito Democratico,Lazio 2,Chamber of Deputies
+397,FERRARA Francesco Detto Ciccio,FERRARA,Sinistra ecologia e libertà,Emilia-Romagna,Chamber of Deputies
+686236,Ferraresi Vittorio,Ferraresi,Movimento 5 stelle,Emilia-Romagna,Chamber of Deputies
+86544,FERRARI Alan,FERRARI,Partito Democratico,Lombardia 3,Chamber of Deputies
+569451,FERRO Andrea,FERRO,Partito Democratico,Lazio 1,Chamber of Deputies
+401,FIANO Emanuele,FIANO,Partito Democratico,Lombardia 1,Chamber of Deputies
+494864,FICO Roberto,FICO,Movimento 5 stelle,Campania 1,Chamber of Deputies
+408,FIORIO Massimo,FIORIO,Partito Democratico,Piemonte 2,Chamber of Deputies
+409,FIORONI Giuseppe,FIORONI,Partito Democratico,Lazio 2,Chamber of Deputies
+5148,FOLINO Vincenzo,FOLINO,Partito Democratico,Basilicata,Chamber of Deputies
+417,FONTANA Gregorio,FONTANA,Popolo della Libertà,Lombardia 2,Chamber of Deputies
+416,FONTANA Cinzia Maria,FONTANA,Partito Democratico,Lombardia 3,Chamber of Deputies
+118198,FONTANELLI Paolo,FONTANELLI,Partito Democratico,Toscana,Chamber of Deputies
+1573,FORMISANO Aniello,FORMISANO,Gruppo Misto,Campania 1,Chamber of Deputies
+4799,FOSSATI Filippo,FOSSATI,Partito Democratico,Toscana,Chamber of Deputies
+687245,Fraccaro Riccardo,Fraccaro,Movimento 5 stelle,Trentino-Alto Adige,Chamber of Deputies
+182044,FRAGOMELI Gian Mario,FRAGOMELI,Partito Democratico,Lombardia 2,Chamber of Deputies
+423,FRANCESCHINI Dario,FRANCESCHINI,Partito Democratico,Emilia-Romagna,Chamber of Deputies
+498902,FRATOIANNI Nicola,FRATOIANNI,Sinistra ecologia e libertà,Puglia,Chamber of Deputies
+475647,Fregolent Silvia,Fregolent,Partito Democratico,Piemonte 1,Chamber of Deputies
+687357,Frusone Luca,Frusone,Movimento 5 stelle,Lazio 2,Chamber of Deputies
+221790,FUCCI Benedetto,FUCCI,Popolo della Libertà,Puglia,Chamber of Deputies
+686475,Furnari Alessandro,Furnari,Gruppo Misto,Puglia,Chamber of Deputies
+384779,Fusilli Gianluca,Fusilli,Partito Democratico,Abruzzo,Chamber of Deputies
+481664,Gadda Maria Chiara,Gadda,Partito Democratico,Lombardia 2,Chamber of Deputies
+686712,Gagnarli Chiara,Gagnarli,Movimento 5 stelle,Toscana,Chamber of Deputies
+4593,GALAN Giancarlo,GALAN,Popolo della Libertà,Veneto 1,Chamber of Deputies
+435,GALATI Giuseppe,GALATI,Popolo della Libertà,Calabria,Chamber of Deputies
+686737,Galgano Adriana,Galgano,Scelta civica per l'Italia,Umbria,Chamber of Deputies
+686197,Galli Carlo,Galli,Partito Democratico,Emilia-Romagna,Chamber of Deputies
+686290,Galli Giampaolo,Galli,Partito Democratico,Lombardia 1,Chamber of Deputies
+494873,GALLINELLA Filippo,GALLINELLA,Movimento 5 stelle,Umbria,Chamber of Deputies
+686133,Gallo Luigi,Gallo,Movimento 5 stelle,Campania 1,Chamber of Deputies
+388995,Gallo Afflitto Riccardo Antonio,Gallo Afflitto,Popolo della Libertà,Sicilia 1,Chamber of Deputies
+4534,GALPERTI Guido,GALPERTI,Partito Democratico,Lombardia 2,Chamber of Deputies
+686222,Gandolfi Paolo,Gandolfi,Partito Democratico,Emilia-Romagna,Chamber of Deputies
+332722,GARAVINI Laura,GARAVINI,Partito Democratico,Europa,Chamber of Deputies
+444,GARNERO SANTANCHE' Daniela,GARNERO SANTANCHE',Popolo della Libertà,Lombardia 3,Chamber of Deputies
+332723,GAROFALO Vincenzo,GAROFALO,Area Popolare (NCD-UDC),Sicilia 2,Chamber of Deputies
+445,GAROFANI Francesco Saverio,GAROFANI,Partito Democratico,Lazio 1,Chamber of Deputies
+7564,GASPARINI Daniela,GASPARINI,Partito Democratico,Lombardia 1,Chamber of Deputies
+29025,GEBHARD Renate,GEBHARD,Gruppo Misto,Trentino-Alto Adige,Chamber of Deputies
+4770,GELLI Federico,GELLI,Partito Democratico,Toscana,Chamber of Deputies
+447,GELMINI Mariastella,GELMINI,Popolo della Libertà,Lombardia 2,Chamber of Deputies
+73346,GENOVESE Francantonio,GENOVESE,Partito Democratico,Sicilia 2,Chamber of Deputies
+449,GENTILONI SILVERI Paolo,GENTILONI SILVERI,Partito Democratico,Lazio 1,Chamber of Deputies
+452,GHIZZONI Manuela,GHIZZONI,Partito Democratico,Emilia-Romagna,Chamber of Deputies
+453,GIACHETTI Roberto,GIACHETTI,Partito Democratico,Lazio 1,Chamber of Deputies
+686267,Giacobbe Anna,Giacobbe,Partito Democratico,Liguria,Chamber of Deputies
+454,GIACOMELLI Antonello,GIACOMELLI,Partito Democratico,Toscana,Chamber of Deputies
+455,GIACOMONI Sestino,GIACOMONI,Popolo della Libertà,Lazio 1,Chamber of Deputies
+332726,GIAMMANCO Gabriella,GIAMMANCO,Popolo della Libertà,Sicilia 1,Chamber of Deputies
+686264,Gigli Gian Luigi,Gigli,Per L'Italia,Friuli-Venezia Giulia,Chamber of Deputies
+352306,Ginato Federico,Ginato,Partito Democratico,Veneto 1,Chamber of Deputies
+21695,GINEFRA Dario,GINEFRA,Partito Democratico,Puglia,Chamber of Deputies
+4922,GINOBLE Tommaso,GINOBLE,Partito Democratico,Abruzzo,Chamber of Deputies
+686012,Giordano Silvia,Giordano,Movimento 5 stelle,Campania 2,Chamber of Deputies
+20398,GIORDANO Giancarlo,GIORDANO,Sinistra ecologia e libertà,Campania 2,Chamber of Deputies
+460,GIORGETTI Giancarlo,GIORGETTI,Lega Nord e autonomie,Lombardia 2,Chamber of Deputies
+459,GIORGETTI Alberto,GIORGETTI,Popolo della Libertà,Veneto 1,Chamber of Deputies
+319282,Giorgis Andrea,Giorgis,Partito Democratico,Piemonte 1,Chamber of Deputies
+686392,Gitti Gregorio,Gitti,Partito Democratico,Lombardia 2,Chamber of Deputies
+686308,Giuliani Fabrizia,Giuliani,Partito Democratico,Lombardia 1,Chamber of Deputies
+88982,GIULIETTI Giampiero,GIULIETTI,Partito Democratico,Umbria,Chamber of Deputies
+6442,GNECCHI Maria Luisa,GNECCHI,Partito Democratico,Trentino-Alto Adige,Chamber of Deputies
+468,GOZI Sandro,GOZI,Partito Democratico,Lombardia 2,Chamber of Deputies
+687324,Grande Marta,Grande,Movimento 5 stelle,Lazio 1,Chamber of Deputies
+469,GRASSI Gero,GRASSI,Partito Democratico,Puglia,Chamber of Deputies
+686652,Greco Maria Gaetana,Greco,Partito Democratico,Sicilia 2,Chamber of Deputies
+530483,Gregori Monica,Gregori,Partito Democratico,Lazio 1,Chamber of Deputies
+292004,Gribaudo Chiara,Gribaudo,Partito Democratico,Piemonte 2,Chamber of Deputies
+686658,Grillo Giulia,Grillo,Movimento 5 stelle,Sicilia 2,Chamber of Deputies
+473,GRIMOLDI Paolo,GRIMOLDI,Lega Nord e autonomie,Lombardia 1,Chamber of Deputies
+26700,GUERINI Giuseppe,GUERINI,Partito Democratico,Lombardia 2,Chamber of Deputies
+183561,GUERINI Lorenzo,GUERINI,Partito Democratico,Lombardia 3,Chamber of Deputies
+233459,GUERRA Mauro,GUERRA,Partito Democratico,Lombardia 2,Chamber of Deputies
+549877,Guidesi Guido,Guidesi,Lega Nord e autonomie,Lombardia 3,Chamber of Deputies
+686656,Gullo Maria Tindara,Gullo,Partito Democratico,Sicilia 2,Chamber of Deputies
+686744,Gutgeld Itzhak Yoram,Gutgeld,Partito Democratico,Abruzzo,Chamber of Deputies
+561083,IACONO Maria,IACONO,Partito Democratico,Sicilia 1,Chamber of Deputies
+478,IANNUZZI Tino,IANNUZZI,Partito Democratico,Campania 2,Chamber of Deputies
+687355,Iannuzzi Cristian,Iannuzzi,Gruppo Misto,Lazio 2,Chamber of Deputies
+304594,Impegno Leonardo,Impegno,Partito Democratico,Campania 1,Chamber of Deputies
+122285,INCERTI Antonella,INCERTI,Partito Democratico,Emilia-Romagna,Chamber of Deputies
+415851,Invernizzi Cristian,Invernizzi,Lega Nord e autonomie,Lombardia 2,Chamber of Deputies
+686228,Iori Vanna,Iori,Partito Democratico,Emilia-Romagna,Chamber of Deputies
+687748,Kronbichler Florian,Kronbichler,Sinistra ecologia e libertà,Trentino-Alto Adige,Chamber of Deputies
+686469,L'Abbate Giuseppe,L'Abbate,Movimento 5 stelle,Puglia,Chamber of Deputies
+687598,La Marca Francesca,La Marca,Partito Democratico,America settentrionale e centrale,Chamber of Deputies
+486,LA RUSSA Ignazio,LA RUSSA,Fratelli d'Italia - Centrodestra Nazionale,Lombardia 1,Chamber of Deputies
+686481,Labriola Vincenza,Labriola,Gruppo Misto,Puglia,Chamber of Deputies
+685963,Lacquaniti Luigi,Lacquaniti,Partito Democratico,Lombardia 2,Chamber of Deputies
+4857,LAFFRANCO Pietro,LAFFRANCO,Popolo della Libertà,Umbria,Chamber of Deputies
+686301,Laforgia Francesco,Laforgia,Partito Democratico,Lombardia 1,Chamber of Deputies
+488,LAINATI Giorgio,LAINATI,Popolo della Libertà,Liguria,Chamber of Deputies
+5139,LATRONICO Cosimo,LATRONICO,Popolo della Libertà,Basilicata,Chamber of Deputies
+429053,Lattuca Enzo,Lattuca,Partito Democratico,Emilia-Romagna,Chamber of Deputies
+686558,Lauricella Giuseppe,Lauricella,Partito Democratico,Sicilia 2,Chamber of Deputies
+14405,LAVAGNO Fabio,LAVAGNO,Partito Democratico,Piemonte 2,Chamber of Deputies
+499,LENZI Donata,LENZI,Partito Democratico,Emilia-Romagna,Chamber of Deputies
+503,LETTA Enrico,LETTA,Partito Democratico,Marche,Chamber of Deputies
+178776,LEVA Danilo,LEVA,Partito Democratico,Molise,Chamber of Deputies
+170575,LIBRANDI Gianfranco,LIBRANDI,Scelta civica per l'Italia,Lombardia 1,Chamber of Deputies
+685739,Liuzzi Mirella,Liuzzi,Movimento 5 stelle,Basilicata,Chamber of Deputies
+510,LO MONTE Carmelo,LO MONTE,Per L'Italia,Sicilia 2,Chamber of Deputies
+686315,Locatelli Pia,Locatelli,Gruppo Misto,Lombardia 1,Chamber of Deputies
+280046,Lodolini Emanuele,Lodolini,Partito Democratico,Marche,Chamber of Deputies
+687326,Lombardi Roberta,Lombardi,Movimento 5 stelle,Lazio 1,Chamber of Deputies
+333166,LONGO Piero,LONGO,Popolo della Libertà,Veneto 1,Chamber of Deputies
+686664,Lorefice Marialucia,Lorefice,Movimento 5 stelle,Sicilia 2,Chamber of Deputies
+332735,LORENZIN Beatrice,LORENZIN,Area Popolare (NCD-UDC),Lazio 1,Chamber of Deputies
+332736,LOSACCO Alberto,LOSACCO,Partito Democratico,Puglia,Chamber of Deputies
+241758,LOTTI Luca,LOTTI,Partito Democratico,Toscana,Chamber of Deputies
+523,LUPI Maurizio Enzo,LUPI,Area Popolare (NCD-UDC),Lombardia 1,Chamber of Deputies
+686535,Lupo Loredana,Lupo,Movimento 5 stelle,Sicilia 1,Chamber of Deputies
+332739,MADIA Maria Anna,MADIA,Partito Democratico,Lazio 1,Chamber of Deputies
+686203,Maestri Patrizia,Maestri,Partito Democratico,Emilia-Romagna,Chamber of Deputies
+234144,MAGORNO Ernesto,MAGORNO,Partito Democratico,Calabria,Chamber of Deputies
+363415,Maietta Pasquale,Maietta,Fratelli d'Italia - Centrodestra Nazionale,Lazio 2,Chamber of Deputies
+168561,MALISANI Gianna,MALISANI,Partito Democratico,Friuli-Venezia Giulia,Chamber of Deputies
+631883,MALPEZZI  Simona Flavia,MALPEZZI,Partito Democratico,Lombardia 1,Chamber of Deputies
+4818,MANCIULLI Andrea,MANCIULLI,Partito Democratico,Toscana,Chamber of Deputies
+686183,Manfredi Massimiliano,Manfredi,Partito Democratico,Campania 1,Chamber of Deputies
+686539,Mannino Claudia,Mannino,Movimento 5 stelle,Sicilia 1,Chamber of Deputies
+686279,Mantero Matteo,Mantero,Movimento 5 stelle,Liguria,Chamber of Deputies
+504405,Manzi Irene,Manzi,Partito Democratico,Marche,Chamber of Deputies
+532,MARANTELLI Daniele,MARANTELLI,Partito Democratico,Lombardia 2,Chamber of Deputies
+687338,Marazziti Mario,Marazziti,Per L'Italia,Lazio 1,Chamber of Deputies
+686417,Marchetti Marco,Marchetti,Partito Democratico,Marche,Chamber of Deputies
+535,MARCHI Maino,MARCHI,Partito Democratico,Emilia-Romagna,Chamber of Deputies
+165485,MARCOLIN Marco,MARCOLIN,Lega Nord e autonomie,Veneto 2,Chamber of Deputies
+685827,Marcon Giulio,Marcon,Sinistra ecologia e libertà,Veneto 2,Chamber of Deputies
+687445,Marguerettaz Rudi Franco,Marguerettaz,Lega Nord e autonomie,Valle d'Aosta,Chamber of Deputies
+537,MARIANI Raffaella,MARIANI,Partito Democratico,Liguria,Chamber of Deputies
+686455,Mariano Elisa,Mariano,Partito Democratico,Puglia,Chamber of Deputies
+128890,MAROTTA Antonio,MAROTTA,Popolo della Libertà,Campania 1,Chamber of Deputies
+275052,MARROCU Siro,MARROCU,Partito Democratico,Sardegna,Chamber of Deputies
+125708,MARRONI Umberto,MARRONI,Partito Democratico,Lazio 1,Chamber of Deputies
+543,MARTELLA Andrea,MARTELLA,Partito Democratico,Veneto 2,Chamber of Deputies
+415790,Martelli Giovanna,Martelli,Partito Democratico,Lombardia 3,Chamber of Deputies
+68256,MARTI Roberto,MARTI,Popolo della Libertà,Puglia,Chamber of Deputies
+544,MARTINELLI Marco,MARTINELLI,Popolo della Libertà,Toscana,Chamber of Deputies
+546,MARTINO Antonio,MARTINO,Popolo della Libertà,Sicilia 2,Chamber of Deputies
+332742,MARTINO Pierdomenico,MARTINO,Partito Democratico,Lazio 2,Chamber of Deputies
+686662,Marzana Maria,Marzana,Movimento 5 stelle,Sicilia 2,Chamber of Deputies
+686294,Marzano Michela,Marzano,Partito Democratico,Lombardia 1,Chamber of Deputies
+721561,MASSA Federico,MASSA,Partito Democratico,Puglia,Chamber of Deputies
+34065,MATARRELLI Antonio,MATARRELLI,Sinistra ecologia e libertà,Puglia,Chamber of Deputies
+686489,Matarrese Salvatore,Matarrese,Scelta civica per l'Italia,Puglia,Chamber of Deputies
+687372,Mattiello Davide,Mattiello,Partito Democratico,Piemonte 1,Chamber of Deputies
+7527,MAURI Matteo,MAURI,Partito Democratico,Lombardia 1,Chamber of Deputies
+686008,Mazziotti Di Celso Andrea,Mazziotti Di Celso,Scelta civica per l'Italia,Lombardia 3,Chamber of Deputies
+9100,MAZZOLI Alessandro,MAZZOLI,Partito Democratico,Lazio 2,Chamber of Deputies
+687448,Melilla Gianni,Melilla,Sinistra ecologia e libertà,Abruzzo,Chamber of Deputies
+8295,MELILLI Fabio,MELILLI,Partito Democratico,Lazio 2,Chamber of Deputies
+556,MELONI Giorgia,MELONI,Fratelli d'Italia - Centrodestra Nazionale,Campania 1,Chamber of Deputies
+275049,MELONI Marco,MELONI,Partito Democratico,Liguria,Chamber of Deputies
+560,MERLO Ricardo Antonio,MERLO,Gruppo Misto,America meridionale,Chamber of Deputies
+562,META Michele Pompeo,META,Partito Democratico,Lazio 1,Chamber of Deputies
+364324,Miccoli Marco,Miccoli,Partito Democratico,Lazio 1,Chamber of Deputies
+685893,Micillo Salvatore,Micillo,Movimento 5 stelle,Campania 1,Chamber of Deputies
+566,MIGLIORE Gennaro,MIGLIORE,Partito Democratico,Campania 1,Chamber of Deputies
+569,MILANATO Lorena,MILANATO,Popolo della Libertà,Veneto 1,Chamber of Deputies
+332750,MINARDO Antonino,MINARDO,Area Popolare (NCD-UDC),Sicilia 2,Chamber of Deputies
+124341,MINNUCCI Emiliano,MINNUCCI,Partito Democratico,Lazio 1,Chamber of Deputies
+332751,MIOTTO Anna Margherita,MIOTTO,Partito Democratico,Veneto 1,Chamber of Deputies
+573,MISIANI Antonio,MISIANI,Partito Democratico,Lombardia 2,Chamber of Deputies
+274982,MISURACA Salvatore,MISURACA,Area Popolare (NCD-UDC),Sicilia 1,Chamber of Deputies
+171845,MOGNATO Michele,MOGNATO,Partito Democratico,Veneto 2,Chamber of Deputies
+686040,Molea Bruno,Molea,Scelta civica per l'Italia,Emilia-Romagna,Chamber of Deputies
+332756,MOLTENI Nicola,MOLTENI,Lega Nord e autonomie,Lombardia 2,Chamber of Deputies
+578,MONACO Francesco,MONACO,Partito Democratico,Lombardia 1,Chamber of Deputies
+685900,Monchiero Giovanni,Monchiero,Scelta civica per l'Italia,Piemonte 1,Chamber of Deputies
+1648,MONGIELLO Colomba,MONGIELLO,Partito Democratico,Puglia,Chamber of Deputies
+28162,MONTRONI Daniele,MONTRONI,Partito Democratico,Emilia-Romagna,Chamber of Deputies
+89354,MORANI Alessia,MORANI,Partito Democratico,Marche,Chamber of Deputies
+313972,Morassut Roberto,Morassut,Partito Democratico,Lazio 1,Chamber of Deputies
+171574,MORETTO Sara,MORETTO,Partito Democratico,Veneto 2,Chamber of Deputies
+687602,Moscatt Antonino,Moscatt,Partito Democratico,Sicilia 1,Chamber of Deputies
+332758,MOTTOLA Giovanni Carlo Francesco,MOTTOLA,Popolo della Libertà,Emilia-Romagna,Chamber of Deputies
+686046,Mucci Mara,Mucci,Gruppo Misto,Emilia-Romagna,Chamber of Deputies
+34758,MURA Romina,MURA,Partito Democratico,Sardegna,Chamber of Deputies
+171881,MURER Delia,MURER,Partito Democratico,Veneto 2,Chamber of Deputies
+592,NACCARATO Alessandro,NACCARATO,Partito Democratico,Veneto 1,Chamber of Deputies
+300093,Nardi Martina,Nardi,Partito Democratico,Toscana,Chamber of Deputies
+687254,Narduolo Giulia,Narduolo,Partito Democratico,Veneto 1,Chamber of Deputies
+4409,NASTRI Gaetano,NASTRI,Fratelli d'Italia - Centrodestra Nazionale,Piemonte 2,Chamber of Deputies
+685792,Nesci Dalila,Nesci,Movimento 5 stelle,Calabria,Chamber of Deputies
+497764,Nesi Edoardo,Nesi,Gruppo Misto,Toscana,Chamber of Deputies
+602,NICCHI Marisa,NICCHI,Sinistra ecologia e libertà,Toscana,Chamber of Deputies
+687239,Nicoletti Michele,Nicoletti,Partito Democratico,Trentino-Alto Adige,Chamber of Deputies
+687604,Nissoli Angela Rosaria Detta Fucsia,Nissoli,Per L'Italia,America settentrionale e centrale,Chamber of Deputies
+223058,NIZZI Settimo,NIZZI,Popolo della Libertà,Sardegna,Chamber of Deputies
+686529,Nuti Riccardo,Nuti,Movimento 5 stelle,Sicilia 1,Chamber of Deputies
+274892,OCCHIUTO Roberto,OCCHIUTO,Popolo della Libertà,Calabria,Chamber of Deputies
+686287,Oliaro Roberta,Oliaro,Scelta civica per l'Italia,Liguria,Chamber of Deputies
+606,OLIVERIO Nicodemo Nazzareno,OLIVERIO,Partito Democratico,Calabria,Chamber of Deputies
+686772,Orfini Matteo,Orfini,Partito Democratico,Lazio 1,Chamber of Deputies
+609,ORLANDO Andrea,ORLANDO,Partito Democratico,Liguria,Chamber of Deputies
+161948,OTTOBRE Mauro,OTTOBRE,Gruppo Misto,Trentino-Alto Adige,Chamber of Deputies
+120760,PAGANI Alberto,PAGANI,Partito Democratico,Emilia-Romagna,Chamber of Deputies
+274928,PAGANO Alessandro,PAGANO,Area Popolare (NCD-UDC),Sicilia 1,Chamber of Deputies
+687453,Paglia Giovanni,Paglia,Sinistra ecologia e libertà,Emilia-Romagna,Chamber of Deputies
+687428,Palazzotto Erasmo,Palazzotto,Sinistra ecologia e libertà,Sicilia 1,Chamber of Deputies
+5097,PALESE Rocco,PALESE,Popolo della Libertà,Puglia,Chamber of Deputies
+686180,Palma Giovanna,Palma,Partito Democratico,Campania 1,Chamber of Deputies
+614,PALMIERI Antonio,PALMIERI,Popolo della Libertà,Lombardia 2,Chamber of Deputies
+333220,PALMIZIO Elio Massimo,PALMIZIO,Popolo della Libertà,Emilia-Romagna,Chamber of Deputies
+686485,Pannarale Annalisa,Pannarale,Sinistra ecologia e libertà,Puglia,Chamber of Deputies
+686114,Parentela Paolo,Parentela,Movimento 5 stelle,Calabria,Chamber of Deputies
+20344,PARIS Valentina,PARIS,Partito Democratico,Campania 2,Chamber of Deputies
+332768,PARISI Massimo,PARISI,Popolo della Libertà,Toscana,Chamber of Deputies
+242166,PARRINI Dario,PARRINI,Partito Democratico,Toscana,Chamber of Deputies
+8312,PASTORELLI Oreste,PASTORELLI,Gruppo Misto,Veneto 2,Chamber of Deputies
+244605,PASTORINO Luca,PASTORINO,Partito Democratico,Liguria,Chamber of Deputies
+687365,Patriarca Edoardo,Patriarca,Partito Democratico,Piemonte 1,Chamber of Deputies
+5102,PELILLO Michele,PELILLO,Partito Democratico,Puglia,Chamber of Deputies
+687455,Pellegrino Serena,Pellegrino,Sinistra ecologia e libertà,Friuli-Venezia Giulia,Chamber of Deputies
+76353,PELUFFO Vinicio,PELUFFO,Partito Democratico,Lombardia 1,Chamber of Deputies
+332771,PES Caterina,PES,Partito Democratico,Sardegna,Chamber of Deputies
+686338,Pesco Daniele,Pesco,Movimento 5 stelle,Lombardia 1,Chamber of Deputies
+686389,Petraroli Cosimo,Petraroli,Movimento 5 stelle,Lombardia 2,Chamber of Deputies
+332772,PETRENGA Giovanna,PETRENGA,Popolo della Libertà,Campania 2,Chamber of Deputies
+4889,PETRINI Paolo,PETRINI,Partito Democratico,Marche,Chamber of Deputies
+687460,Piazzoni Ileana,Piazzoni,Partito Democratico,Lazio 1,Chamber of Deputies
+644,PICCHI Guglielmo,PICCHI,Popolo della Libertà,Europa,Chamber of Deputies
+389343,Piccione Teresa,Piccione,Partito Democratico,Sicilia 1,Chamber of Deputies
+686554,Piccoli Nardelli Flavia,Piccoli Nardelli,Partito Democratico,Sicilia 2,Chamber of Deputies
+332874,PICCOLO Salvatore,PICCOLO,Partito Democratico,Campania 1,Chamber of Deputies
+686185,Piccolo Giorgio,Piccolo,Partito Democratico,Campania 1,Chamber of Deputies
+1680,PICCONE Filippo,PICCONE,Area Popolare (NCD-UDC),Abruzzo,Chamber of Deputies
+686492,Piepoli Gaetano,Piepoli,Per L'Italia,Puglia,Chamber of Deputies
+647,PILI Mauro,PILI,Gruppo Misto,Sardegna,Chamber of Deputies
+243618,PILOZZI Nazzareno,PILOZZI,Partito Democratico,Lazio 2,Chamber of Deputies
+686218,Pini Giuditta,Pini,Partito Democratico,Emilia-Romagna,Chamber of Deputies
+648,PINI Gianluca,PINI,Lega Nord e autonomie,Emilia-Romagna,Chamber of Deputies
+686509,Pinna Paola,Pinna,Gruppo Misto,Sardegna,Chamber of Deputies
+686503,Piras Michele,Piras,Sinistra ecologia e libertà,Sardegna,Chamber of Deputies
+686164,Pisano Girolamo,Pisano,Movimento 5 stelle,Campania 2,Chamber of Deputies
+653,PISICCHIO Pino,PISICCHIO,Gruppo Misto,Puglia,Chamber of Deputies
+125686,PISO Vincenzo,PISO,Area Popolare (NCD-UDC),Lazio 2,Chamber of Deputies
+54,PISTELLI Lapo,PISTELLI,Partito Democratico,Emilia-Romagna,Chamber of Deputies
+654,PIZZOLANTE Sergio,PIZZOLANTE,Area Popolare (NCD-UDC),Emilia-Romagna,Chamber of Deputies
+119774,PLACIDO Antonio,PLACIDO,Sinistra ecologia e libertà,Basilicata,Chamber of Deputies
+29101,PLANGGER Albrecht,PLANGGER,Gruppo Misto,Trentino-Alto Adige,Chamber of Deputies
+332878,POLIDORI Catia,POLIDORI,Popolo della Libertà,Veneto 1,Chamber of Deputies
+656,POLLASTRINI Barbara,POLLASTRINI,Partito Democratico,Lombardia 1,Chamber of Deputies
+494771,POLVERINI Renata,POLVERINI,Popolo della Libertà,Lazio 1,Chamber of Deputies
+332880,PORTA Fabio,PORTA,Partito Democratico,America meridionale,Chamber of Deputies
+332882,PORTAS Giacomo Antonio,PORTAS,Partito Democratico,Piemonte 1,Chamber of Deputies
+418631,PRATAVIERA Emanuele,PRATAVIERA,Lega Nord e autonomie,Veneto 2,Chamber of Deputies
+662,PRESTIGIACOMO Stefania,PRESTIGIACOMO,Popolo della Libertà,Sicilia 2,Chamber of Deputies
+686351,Preziosi Ernesto,Preziosi,Partito Democratico,Lombardia 2,Chamber of Deputies
+4575,PRINA Francesco,PRINA,Partito Democratico,Lombardia 1,Chamber of Deputies
+686262,Prodani Aris,Prodani,Gruppo Misto,Friuli-Venezia Giulia,Chamber of Deputies
+686277,Quaranta Stefano,Quaranta,Sinistra ecologia e libertà,Liguria,Chamber of Deputies
+686297,Quartapelle Procopio Lia,Quartapelle Procopio,Partito Democratico,Lombardia 1,Chamber of Deputies
+687289,Quintarelli Stefano,Quintarelli,Scelta civica per l'Italia,Veneto 1,Chamber of Deputies
+4445,RABINO Mariano,RABINO,Scelta civica per l'Italia,Piemonte 2,Chamber of Deputies
+686560,Raciti Fausto,Raciti,Partito Democratico,Sicilia 2,Chamber of Deputies
+5017,RAGOSTA Michele,RAGOSTA,Partito Democratico,Campania 2,Chamber of Deputies
+670,RAMPELLI Fabio,RAMPELLI,Fratelli d'Italia - Centrodestra Nazionale,Lazio 1,Chamber of Deputies
+325708,Rampi Roberto,Rampi,Partito Democratico,Lombardia 1,Chamber of Deputies
+674,RAVETTO Laura,RAVETTO,Popolo della Libertà,Lombardia 2,Chamber of Deputies
+676,REALACCI Ermete,REALACCI,Partito Democratico,Lombardia 2,Chamber of Deputies
+385100,Ribaudo Francesco,Ribaudo,Partito Democratico,Sicilia 1,Chamber of Deputies
+687431,Ricciatti Lara,Ricciatti,Sinistra ecologia e libertà,Marche,Chamber of Deputies
+4755,RICHETTI Matteo,RICHETTI,Partito Democratico,Emilia-Romagna,Chamber of Deputies
+681,RIGONI Andrea,RIGONI,Partito Democratico,Toscana,Chamber of Deputies
+686259,Rizzetto Walter,Rizzetto,Gruppo Misto,Friuli-Venezia Giulia,Chamber of Deputies
+686668,Rizzo Gianluca,Rizzo,Movimento 5 stelle,Sicilia 2,Chamber of Deputies
+332892,ROCCELLA Eugenia Maria,ROCCELLA,Area Popolare (NCD-UDC),Lazio 1,Chamber of Deputies
+686682,Rocchi Maria Grazia,Rocchi,Partito Democratico,Toscana,Chamber of Deputies
+85079,ROMANINI Giuseppe,ROMANINI,Partito Democratico,Emilia-Romagna,Chamber of Deputies
+686,ROMANO Francesco Saverio,ROMANO,Popolo della Libertà,Sicilia 1,Chamber of Deputies
+686720,Romano Andrea,Romano,Partito Democratico,Toscana,Chamber of Deputies
+687398,Romano Paolo Nicolò,Romano,Movimento 5 stelle,Piemonte 2,Chamber of Deputies
+687,ROMELE Giuseppe,ROMELE,Popolo della Libertà,Lombardia 2,Chamber of Deputies
+332894,RONDINI Marco,RONDINI,Lega Nord e autonomie,Lombardia 1,Chamber of Deputies
+177665,ROSATO Ettore,ROSATO,Partito Democratico,Friuli-Venezia Giulia,Chamber of Deputies
+687340,Rossi Domenico,Rossi,Per L'Italia,Lazio 1,Chamber of Deputies
+1707,ROSSI Paolo,ROSSI,Partito Democratico,"",Chamber of Deputies
+332898,ROSSOMANDO Anna,ROSSOMANDO,Partito Democratico,Piemonte 1,Chamber of Deputies
+686175,Rostan Michela,Rostan,Partito Democratico,Campania 1,Chamber of Deputies
+685848,Rostellato Gessica,Rostellato,Gruppo Misto,Veneto 1,Chamber of Deputies
+1708,ROTONDI Gianfranco,ROTONDI,Popolo della Libertà,Campania 1,Chamber of Deputies
+687272,Rotta Alessia,Rotta,Partito Democratico,Veneto 1,Chamber of Deputies
+1709,RUBINATO Simonetta,RUBINATO,Partito Democratico,Veneto 2,Chamber of Deputies
+686152,Rughetti Angelo,Rughetti,Partito Democratico,Campania 2,Chamber of Deputies
+687332,Ruocco Carla,Ruocco,Movimento 5 stelle,Lazio 1,Chamber of Deputies
+700,RUSSO Paolo,RUSSO,Popolo della Libertà,Campania 1,Chamber of Deputies
+8344,SALTAMARTINI Barbara,SALTAMARTINI,Gruppo Misto,Lazio 2,Chamber of Deputies
+274855,SAMMARCO Gianfranco,SAMMARCO,Area Popolare (NCD-UDC),Lazio 1,Chamber of Deputies
+707,SANGA Giovanni,SANGA,Partito Democratico,Lombardia 2,Chamber of Deputies
+332906,SANI Luca,SANI,Partito Democratico,Toscana,Chamber of Deputies
+348294,Sanna Giovanna,Sanna,Partito Democratico,Sardegna,Chamber of Deputies
+275029,SANNA Francesco,SANNA,Partito Democratico,Sardegna,Chamber of Deputies
+5068,SANNICANDRO Arcangelo,SANNICANDRO,Sinistra ecologia e libertà,Puglia,Chamber of Deputies
+710,SANTELLI Jole,SANTELLI,Popolo della Libertà,Calabria,Chamber of Deputies
+685978,Santerini Milena,Santerini,Per L'Italia,Lombardia 2,Chamber of Deputies
+333276,SARRO Carlo,SARRO,Popolo della Libertà,Campania 2,Chamber of Deputies
+686044,Sarti Giulia,Sarti,Movimento 5 stelle,Emilia-Romagna,Chamber of Deputies
+177694,SAVINO Sandra,SAVINO,Popolo della Libertà,Friuli-Venezia Giulia,Chamber of Deputies
+332912,SAVINO Elvira,SAVINO,Popolo della Libertà,Puglia,Chamber of Deputies
+686395,Sberna Mario,Sberna,Per L'Italia,Lombardia 2,Chamber of Deputies
+9069,SBROLLINI Daniela,SBROLLINI,Partito Democratico,Veneto 1,Chamber of Deputies
+686477,Scagliusi Emanuele,Scagliusi,Movimento 5 stelle,Puglia,Chamber of Deputies
+686453,Scalfarotto Ivan,Scalfarotto,Partito Democratico,Puglia,Chamber of Deputies
+223060,SCANU Gian Piero,SCANU,Partito Democratico,Sardegna,Chamber of Deputies
+686545,Schirò Gea,Schirò,Partito Democratico,Sicilia 1,Chamber of Deputies
+28912,SCHULLIAN Manfred,SCHULLIAN,Gruppo Misto,Trentino-Alto Adige,Chamber of Deputies
+685790,Scopelliti Rosanna,Scopelliti,Area Popolare (NCD-UDC),Calabria,Chamber of Deputies
+718,SCOTTO Arturo,SCOTTO,Sinistra ecologia e libertà,Campania 1,Chamber of Deputies
+686407,Scuvera Chiara,Scuvera,Partito Democratico,Lombardia 3,Chamber of Deputies
+686714,Segoni Samuele,Segoni,Gruppo Misto,Toscana,Chamber of Deputies
+169757,SENALDI Angelo,SENALDI,Partito Democratico,Lombardia 2,Chamber of Deputies
+720,SERENI Marina,SERENI,Partito Democratico,Umbria,Chamber of Deputies
+687658,Sgambato Camilla,Sgambato,Partito Democratico,Campania 2,Chamber of Deputies
+686014,Sibilia Carlo,Sibilia,Movimento 5 stelle,Campania 2,Chamber of Deputies
+9270,SIMONETTI Roberto,SIMONETTI,Lega Nord e autonomie,Piemonte 2,Chamber of Deputies
+241653,SIMONI Elisa,SIMONI,Partito Democratico,Toscana,Chamber of Deputies
+332920,SISTO Francesco Paolo,SISTO,Popolo della Libertà,Puglia,Chamber of Deputies
+686385,Sorial Girgis Giorgio,Sorial,Movimento 5 stelle,Lombardia 2,Chamber of Deputies
+686750,Sottanelli Giulio,Sottanelli,Scelta civica per l'Italia,Abruzzo,Chamber of Deputies
+686234,Spadoni Maria Edera,Spadoni,Movimento 5 stelle,Emilia-Romagna,Chamber of Deputies
+119733,SPERANZA Roberto,SPERANZA,Partito Democratico,Basilicata,Chamber of Deputies
+685811,Spessotto Arianna,Spessotto,Movimento 5 stelle,Veneto 2,Chamber of Deputies
+76488,SQUERI Luca,SQUERI,Popolo della Libertà,Lombardia 1,Chamber of Deputies
+686187,Stumpo Nico,Stumpo,Partito Democratico,Calabria,Chamber of Deputies
+740,TABACCI Bruno,TABACCI,Per L'Italia,Toscana,Chamber of Deputies
+687613,Tacconi Alessio,Tacconi,Gruppo Misto,Europa,Chamber of Deputies
+741,TAGLIALATELA Marcello,TAGLIALATELA,Fratelli d'Italia - Centrodestra Nazionale,Campania 1,Chamber of Deputies
+4927,TANCREDI Paolo,TANCREDI,Area Popolare (NCD-UDC),Abruzzo,Chamber of Deputies
+686522,Taranto Luigi,Taranto,Partito Democratico,Sicilia 1,Chamber of Deputies
+4466,TARICCO Giacomino,TARICCO,Partito Democratico,Piemonte 2,Chamber of Deputies
+685574,Tartaglione Assunta,Tartaglione,Partito Democratico,Campania 1,Chamber of Deputies
+686356,Tentori Veronica,Tentori,Partito Democratico,Lombardia 2,Chamber of Deputies
+322807,Terrosi Alessandra,Terrosi,Partito Democratico,Lazio 2,Chamber of Deputies
+686433,Terzoni Patrizia,Terzoni,Movimento 5 stelle,Marche,Chamber of Deputies
+313252,Tidei Marietta,Tidei,Partito Democratico,Lazio 1,Chamber of Deputies
+686038,Tinagli Irene,Tinagli,Scelta civica per l'Italia,Emilia-Romagna,Chamber of Deputies
+686011,Tofalo Angelo,Tofalo,Movimento 5 stelle,Campania 2,Chamber of Deputies
+686015,Toninelli Danilo,Toninelli,Movimento 5 stelle,Lombardia 3,Chamber of Deputies
+1745,TOTARO Achille,TOTARO,Fratelli d'Italia - Centrodestra Nazionale,Toscana,Chamber of Deputies
+686336,Tripiedi Davide,Tripiedi,Movimento 5 stelle,Lombardia 1,Chamber of Deputies
+332938,TULLO Mario,TULLO,Partito Democratico,Liguria,Chamber of Deputies
+687299,Turco Tancredi,Turco,Gruppo Misto,Veneto 1,Chamber of Deputies
+685683,Vacca Gianluca,Vacca,Movimento 5 stelle,Abruzzo,Chamber of Deputies
+5000,VACCARO Guglielmo,VACCARO,Partito Democratico,Campania 1,Chamber of Deputies
+304620,Valente Valeria,Valente,Partito Democratico,Campania 1,Chamber of Deputies
+686283,Valente Simone,Valente,Movimento 5 stelle,Liguria,Chamber of Deputies
+767,VALENTINI Valentino,VALENTINI,Popolo della Libertà,Veneto 2,Chamber of Deputies
+8446,VALIANTE Simone,VALIANTE,Partito Democratico,Campania 2,Chamber of Deputies
+686507,Vallascas Andrea,Vallascas,Movimento 5 stelle,Sardegna,Chamber of Deputies
+275037,VARGIU Pierpaolo,VARGIU,Scelta civica per l'Italia,Sardegna,Chamber of Deputies
+316193,Vazio Franco,Vazio,Partito Democratico,Liguria,Chamber of Deputies
+649715,Vecchio Andrea,Vecchio,Scelta civica per l'Italia,Sicilia 2,Chamber of Deputies
+332942,VELLA Paolo,VELLA,Popolo della Libertà,Sardegna,Chamber of Deputies
+769,VELO Silvia,VELO,Partito Democratico,Toscana,Chamber of Deputies
+288027,Venittelli Laura,Venittelli,Partito Democratico,Molise,Chamber of Deputies
+686443,Ventricelli Liliana,Ventricelli,Partito Democratico,Puglia,Chamber of Deputies
+332944,VERINI Walter,VERINI,Partito Democratico,Umbria,Chamber of Deputies
+685890,Vezzali Valentina,Vezzali,Scelta civica per l'Italia,Marche,Chamber of Deputies
+332948,VIGNALI Raffaello,VIGNALI,Area Popolare (NCD-UDC),Lombardia 2,Chamber of Deputies
+687334,Vignaroli Stefano,Vignaroli,Movimento 5 stelle,Lazio 1,Chamber of Deputies
+686669,Villarosa Alessio,Villarosa,Movimento 5 stelle,Sicilia 2,Chamber of Deputies
+1760,VILLECCO CALIPARI Rosa Maria,VILLECCO CALIPARI,Partito Democratico,Lombardia 3,Chamber of Deputies
+685895,Vitelli Paolo,Vitelli,Scelta civica per l'Italia,Piemonte 1,Chamber of Deputies
+785,VITO Elio,VITO,Popolo della Libertà,Piemonte 2,Chamber of Deputies
+687330,Zaccagnini Adriano,Zaccagnini,Sinistra ecologia e libertà,Lazio 1,Chamber of Deputies
+332952,ZAMPA Sandra,ZAMPA,Partito Democratico,Emilia-Romagna,Chamber of Deputies
+82511,ZAN Alessandro,ZAN,Partito Democratico,Veneto 1,Chamber of Deputies
+687315,Zanetti Enrico,Zanetti,Scelta civica per l'Italia,Veneto 2,Chamber of Deputies
+475723,Zanin Giorgio,Zanin,Partito Democratico,Friuli-Venezia Giulia,Chamber of Deputies
+276866,Zappulla Giuseppe,Zappulla,Partito Democratico,Sicilia 2,Chamber of Deputies
+8381,ZARATTI Filiberto,ZARATTI,Sinistra ecologia e libertà,Lazio 1,Chamber of Deputies
+497584,Zardini Diego,Zardini,Partito Democratico,Veneto 1,Chamber of Deputies
+171347,ZOGGIA Davide,ZOGGIA,Partito Democratico,Veneto 1,Chamber of Deputies
+686013,Zolezzi Alberto,Zolezzi,Movimento 5 stelle,Lombardia 3,Chamber of Deputies

--- a/t/test_parlamento.rb
+++ b/t/test_parlamento.rb
@@ -33,14 +33,20 @@ describe "parlamento" do
 
     it "should have correct party info" do
       party_mem = pmems.find { |m| m[:role] == 'representative' }
-      party = orgs.find { |o| party_mem[:organization_id] == o[:id] }
+      party = orgs.find { |o| o[:id] == party_mem[:organization_id] }
       party[:name].must_equal 'Partito Democratico'
       party[:classification].must_equal 'party'
     end
 
     it "should represent correct region" do
-      mem = pmems.find { |m| m[:role] == 'member' }
-      mem[:area][:name].must_equal 'Lazio'
+      leg_mem = pmems.find { |m| m[:role] == 'member' }
+      leg_mem[:area][:name].must_equal 'Lazio'
+    end
+
+    it "should be in correct chamber" do
+      leg_mem = pmems.find { |m| m[:role] == 'member' }
+      chamber = orgs.find { |o| o[:id] == leg_mem[:organization_id] }
+      chamber[:name].must_equal 'Senate'
     end
 
   end

--- a/t/test_parlamento.rb
+++ b/t/test_parlamento.rb
@@ -1,0 +1,63 @@
+#!/usr/bin/ruby
+
+require 'csv_to_popolo'
+require 'minitest/autorun'
+require 'json'
+require 'json-schema'
+require 'pry'
+
+describe "parlamento" do
+
+  subject { 
+    Popolo::CSV.new('t/data/italy.csv')
+  }
+
+  let(:ppl)  { subject.data[:persons] }
+  let(:orgs) { subject.data[:organizations] }
+  let(:mems) { subject.data[:memberships] }
+
+  # 687024,Grasso Pietro,Grasso,Partito Democratico,Lazio,Senate
+
+  describe "grasso" do
+
+    let(:member) { ppl.find { |i| i[:id] == '687024' } }
+    let(:pmems)  { mems.find_all { |m| m[:person_id] == member[:id] } }
+
+    it "should have the correct name" do
+      member[:name].must_include 'Pietro'
+    end
+
+    it "should have the correct family_name" do
+      member[:family_name].must_equal 'Grasso'
+    end
+
+    it "should have correct party info" do
+      party_mem = pmems.find { |m| m[:role] == 'representative' }
+      party = orgs.find { |o| party_mem[:organization_id] == o[:id] }
+      party[:name].must_equal 'Partito Democratico'
+      party[:classification].must_equal 'party'
+    end
+
+    it "should represent correct region" do
+      mem = pmems.find { |m| m[:role] == 'member' }
+      mem[:area][:name].must_equal 'Lazio'
+    end
+
+  end
+
+  describe "validation" do
+
+    it "should have no warnings" do
+      subject.data[:warnings].must_be_nil
+    end
+
+    it "should validate" do
+      json = JSON.parse(subject.data.to_json)
+      %w(person organization membership).each do |type|
+        # JSON::Validator.fully_validate("http://www.popoloproject.com/schemas/#{type}.json", json[type + 's'], :list => true).must_be :empty?
+      end
+    end
+  end
+
+end
+

--- a/t/test_parlamento.rb
+++ b/t/test_parlamento.rb
@@ -18,7 +18,7 @@ describe "parlamento" do
 
   # 687024,Grasso Pietro,Grasso,Partito Democratico,Lazio,Senate
 
-  describe "grasso" do
+  describe "Grasso" do
 
     let(:member) { ppl.find { |i| i[:id] == '687024' } }
     let(:pmems)  { mems.find_all { |m| m[:person_id] == member[:id] } }
@@ -47,6 +47,41 @@ describe "parlamento" do
       leg_mem = pmems.find { |m| m[:role] == 'member' }
       chamber = orgs.find { |o| o[:id] == leg_mem[:organization_id] }
       chamber[:name].must_equal 'Senate'
+    end
+
+  end
+
+  # 686427,Boldrini Laura,Boldrini,Sinistra ecologia e libertà,Sicilia 2,Chamber of Deputies
+  
+  describe "Boldrini" do
+
+    let(:member) { ppl.find { |i| i[:id] == '686427' } }
+    let(:pmems)  { mems.find_all { |m| m[:person_id] == member[:id] } }
+
+    it "should have the correct name" do
+      member[:name].must_include 'Laura'
+    end
+
+    it "should have the correct family_name" do
+      member[:family_name].must_equal 'Boldrini'
+    end
+
+    it "should have correct party info" do
+      party_mem = pmems.find { |m| m[:role] == 'representative' }
+      party = orgs.find { |o| o[:id] == party_mem[:organization_id] }
+      party[:name].must_equal 'Sinistra ecologia e libertà'
+      party[:classification].must_equal 'party'
+    end
+
+    it "should represent correct region" do
+      leg_mem = pmems.find { |m| m[:role] == 'member' }
+      leg_mem[:area][:name].must_equal 'Sicilia 2'
+    end
+
+    it "should be in correct chamber" do
+      leg_mem = pmems.find { |m| m[:role] == 'member' }
+      chamber = orgs.find { |o| o[:id] == leg_mem[:organization_id] }
+      chamber[:name].must_equal 'Chamber of Deputies'
     end
 
   end


### PR DESCRIPTION
Allow CSV files to contain information on multiple chambers, by specifying a `chamber` or `house` on each record. Closes #9
