### PR TITLE
bugfix: add back missing 'legislature' Memberships

### DIFF
--- a/lib/csv_to_popolo.rb
+++ b/lib/csv_to_popolo.rb
@@ -228,7 +228,7 @@ class Popolo
       @_lmems ||= @csv.find_all { |r| r.has_key? :group }.map do |r|
         mem = { 
           person_id:        r[:id],
-          organization_id:  find_chamber_id(r[:chamber]),
+          organization_id:  find_chamber_id(r[:chamber]) || "legislature",
           role:             'member',
           start_date:       r[:start_date],
           end_date:         r[:end_date],

--- a/lib/csv_to_popolo/version.rb
+++ b/lib/csv_to_popolo/version.rb
@@ -1,3 +1,3 @@
 module Popolo_CSV
-  VERSION = "0.7.4"
+  VERSION = "0.7.5"
 end

--- a/t/test_eduskunta.rb
+++ b/t/test_eduskunta.rb
@@ -23,7 +23,12 @@ describe "eduskunta" do
     kesk[:id].must_equal 'kesk'
   end
 
-  it "should only have correct party membership" do
+  it "should have legislative membership" do
+    pm = mems.find_all { |m| m[:organization_id] == 'legislature' }
+    pm.count.must_equal 1
+  end
+
+  it "should have correct party membership" do
     pm = mems.find_all { |m| m[:role] == 'representative' }
     pm.count.must_equal 1
     pm.first[:organization_id].must_equal 'kesk'


### PR DESCRIPTION
https://github.com/tmtmtmtm/csv_to_popolo/commit/903520100b23bf1355dea409538245939f04b093 introduced a bug where bare legislative Memberships could be created without an Organisation.
