### PR TITLE
0.8.3: Add warnings for duplicate column names

### DIFF
--- a/lib/csv_to_popolo.rb
+++ b/lib/csv_to_popolo.rb
@@ -271,10 +271,14 @@ class Popolo
 
     def warnings
       handled = @raw_csv.headers.partition { |got| Popolo.model.has_key? got }
-      return if handled.last.count.zero?
-      {
+      dupes = @raw_csv.headers.group_by { |h| h }.find_all { |h, hs| hs.size > 1 }
+
+      warnings = {
         skipped: handled.last,
-      }
+        dupes: dupes.map { |h, hs| h }
+      }.reject { |_,v| v.nil? or v.empty? }
+      return if warnings.empty?
+      return warnings
     end
 
     private

--- a/lib/csv_to_popolo/version.rb
+++ b/lib/csv_to_popolo/version.rb
@@ -1,3 +1,3 @@
 module Popolo_CSV
-  VERSION = "0.8.2"
+  VERSION = "0.8.3"
 end

--- a/t/data/duplicate_headers.csv
+++ b/t/data/duplicate_headers.csv
@@ -1,0 +1,4 @@
+org,name,name,twitter,mobile,fax,wikipedia
+mySociety,Tom,Steinberg,steiny,tomsphone,,http://en.wikipedia.org/wiki/Tom_Steinberg
+Sunlight Foundation,Ellen,Miller,EllnMllr,ellensphone,ellensfax,http://en.wikipedia.org/wiki/Ellen_S._Miller
+,Orgless,,,,,

--- a/t/test_dupe_headers.rb
+++ b/t/test_dupe_headers.rb
@@ -1,0 +1,15 @@
+#!/usr/bin/ruby
+
+require 'csv_to_popolo'
+require 'minitest/autorun'
+
+describe "duplicate columns" do
+
+  subject     { Popolo::CSV.new('t/data/duplicate_headers.csv') }
+
+  it "should warn about the duplicate name column" do
+    subject.data[:warnings][:dupes].must_include :name
+  end
+
+end
+


### PR DESCRIPTION
If we get multiple columns with the same name, warn about it.

Closes #48 
