### PR TITLE
0.8.4 Handle (and warn about) blank column names

### DIFF
--- a/lib/csv_to_popolo.rb
+++ b/lib/csv_to_popolo.rb
@@ -151,7 +151,7 @@ class Popolo
       headers: true,
       header_converters: lambda { |h| 
         # = HeaderConverters.symbol + remapping
-        hc = h.encode(::CSV::ConverterEncoding).downcase.gsub(/\s+/, "_").gsub(/\W+/, "")
+        hc = h.to_s.encode(::CSV::ConverterEncoding).downcase.gsub(/\s+/, "_").gsub(/\W+/, "")
         (@@key_map[hc] || hc).to_sym
       }
     }
@@ -271,12 +271,14 @@ class Popolo
 
     def warnings
       handled = @raw_csv.headers.partition { |got| Popolo.model.has_key? got }
+      blank = @raw_csv.headers.find_all(&:empty?).count
       dupes = @raw_csv.headers.group_by { |h| h }.find_all { |h, hs| hs.size > 1 }
 
       warnings = {
         skipped: handled.last,
         dupes: dupes.map { |h, hs| h }
       }.reject { |_,v| v.nil? or v.empty? }
+      warnings[:blank] = blank unless blank.zero?
       return if warnings.empty?
       return warnings
     end

--- a/lib/csv_to_popolo/version.rb
+++ b/lib/csv_to_popolo/version.rb
@@ -1,3 +1,3 @@
 module Popolo_CSV
-  VERSION = "0.8.3"
+  VERSION = "0.8.4"
 end

--- a/t/data/empty_headers.csv
+++ b/t/data/empty_headers.csv
@@ -1,0 +1,4 @@
+org,first_name,last_name,twitter,mobile,fax,,wikipedia
+mySociety,Tom,Steinberg,steiny,tomsphone,,http://en.wikipedia.org/wiki/Tom_Steinberg
+Sunlight Foundation,Ellen,Miller,EllnMllr,ellensphone,ellensfax,http://en.wikipedia.org/wiki/Ellen_S._Miller
+,Orgless,,,,,

--- a/t/test_empty_headers.rb
+++ b/t/test_empty_headers.rb
@@ -1,0 +1,19 @@
+#!/usr/bin/ruby
+
+require 'csv_to_popolo'
+require 'minitest/autorun'
+
+describe "blank headers" do
+
+  subject { Popolo::CSV.new('t/data/empty_headers.csv') }
+
+  it "should warn about the empty name column" do
+    subject.data[:warnings][:blank].must_equal 1
+  end
+
+  it "should parse the rest fine" do
+    subject.data[:persons].first[:given_name].must_equal 'Tom'
+  end
+
+end
+


### PR DESCRIPTION
Don’t error if the header row includes a blank column name.

Closes #47
