### PR TITLE
Fully Qualified PersonIDs

### DIFF
--- a/lib/csv_to_popolo.rb
+++ b/lib/csv_to_popolo.rb
@@ -154,10 +154,15 @@ class Popolo
       }
     }
 
+    def self.id_for (type, id)
+      id ||= SecureRandom.uuid
+      return id.include?('/') ? id : "#{type}/#{id}"
+    end
+
     def initialize(file)
       @raw_csv = ::CSV.read(file, @@opts)
       @csv = @raw_csv.map { |r|
-        r[:id] ||= "person/#{SecureRandom.uuid}"
+        r[:id] = CSV.id_for("person", r[:id])
         r.to_hash.select { |_, v| !v.nil? }
       }
     end

--- a/lib/csv_to_popolo/version.rb
+++ b/lib/csv_to_popolo/version.rb
@@ -1,3 +1,3 @@
 module Popolo_CSV
-  VERSION = "0.8.6"
+  VERSION = "0.9.0"
 end

--- a/t/test_eduskunta.rb
+++ b/t/test_eduskunta.rb
@@ -9,8 +9,8 @@ describe "eduskunta" do
     Popolo::CSV.new('t/data/eduskunta.csv')
   }
 
-  let(:ahde)  { subject.data[:persons].find           { |p| p[:id] == '104' } }
-  let(:mems)  { subject.data[:memberships].find_all   { |m| m[:person_id] == '104' } }
+  let(:ahde)  { subject.data[:persons].find           { |p| p[:id] == 'person/104' } }
+  let(:mems)  { subject.data[:memberships].find_all   { |m| m[:person_id] == 'person/104' } }
   let(:kesk)  { subject.data[:organizations].find     { |o| o[:name] == 'Finnish Centre Party' } }
 
   it "should set party name correctly" do

--- a/t/test_eduskunta_mini.rb
+++ b/t/test_eduskunta_mini.rb
@@ -9,15 +9,15 @@ describe "eduskunta" do
     Popolo::CSV.new('t/data/eduskunta_mini.csv')
   }
 
-  let(:aho)  { subject.data[:persons].find { |i| i[:id] == '104' } }
-  let(:mems) { subject.data[:memberships].find_all { |i| i[:person_id] == '104' } }
+  let(:aho)  { subject.data[:persons].find { |i| i[:id] == 'person/104' } }
+  let(:mems) { subject.data[:memberships].find_all { |i| i[:person_id] == 'person/104' } }
 
   it "should have the correct name" do
     aho[:name].must_equal 'Aho Esko'
   end
 
   it "should have the correct id" do
-    aho[:id].must_equal '104'
+    aho[:id].must_equal 'person/104'
   end
 
   it "should have the correct family name" do

--- a/t/test_parlamento.rb
+++ b/t/test_parlamento.rb
@@ -17,7 +17,7 @@ describe "parlamento" do
 
   describe "Grasso" do
 
-    let(:member) { ppl.find { |i| i[:id] == '687024' } }
+    let(:member) { ppl.find { |i| i[:id] == 'person/687024' } }
     let(:pmems)  { mems.find_all { |m| m[:person_id] == member[:id] } }
 
     it "should have the correct name" do
@@ -52,7 +52,7 @@ describe "parlamento" do
   
   describe "Boldrini" do
 
-    let(:member) { ppl.find { |i| i[:id] == '686427' } }
+    let(:member) { ppl.find { |i| i[:id] == 'person/686427' } }
     let(:pmems)  { mems.find_all { |m| m[:person_id] == member[:id] } }
 
     it "should have the correct name" do

--- a/t/test_riigikogu.rb
+++ b/t/test_riigikogu.rb
@@ -21,7 +21,7 @@ describe "riigikogu" do
     end
 
     it "should have the correct id" do
-      arto[:id].must_equal 'fe748f4d-3f50-4af8-8069-92a460978d2b'
+      arto[:id].must_equal 'person/fe748f4d-3f50-4af8-8069-92a460978d2b'
     end
 
     it "should have correct faction info" do

--- a/t/test_riigikogud.rb
+++ b/t/test_riigikogud.rb
@@ -35,7 +35,7 @@ describe "riigikogu" do
     let(:mems)  { subject.data[:memberships].find_all { |m| m[:person_id] == arto[:id] && m[:role] == 'member' } }
 
     it "should have the correct id" do
-      arto[:id].must_equal 'fe748f4d-3f50-4af8-8069-92a460978d2b'
+      arto[:id].must_equal 'person/fe748f4d-3f50-4af8-8069-92a460978d2b'
     end
 
     it "should have two legislative memberships" do

--- a/t/test_wales.rb
+++ b/t/test_wales.rb
@@ -11,7 +11,7 @@ describe "welsh assembly" do
 
   describe "Asghar" do
 
-    let(:asghar) { subject.data[:persons].find { |i| i[:id] == '130' } }
+    let(:asghar) { subject.data[:persons].find { |i| i[:id] == 'person/130' } }
 
     it "should have the correct name" do
       asghar[:name].must_equal 'Mohammad Asghar'
@@ -70,7 +70,7 @@ describe "welsh assembly" do
   describe "First Minister" do
     
     let(:executive) { subject.data[:organizations].find { |o| o[:id] == 'executive' } }
-    let(:fmin) { subject.data[:persons].find         { |p| p[:id] == '102' } }
+    let(:fmin) { subject.data[:persons].find         { |p| p[:id] == 'person/102' } }
     let(:mems) { subject.data[:memberships].find_all { |m| m[:person_id] == fmin[:id] } }
 
     it "should have two memberships" do


### PR DESCRIPTION
If someone gives us a bare ID for a person, prefix it with person/, to
avoid clashes with bare IDs for other fields.

Closes #54
