### PR TITLE
Generate persistent IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ It currently handles data from the following columns:
 * `biography`
 * `national_identity`
 
-(none of these are required — it will simply extra data from any
+(none of these are required — it will simply extract data from any
 suitably-named columns)
 
 ## Party/Faction Membership
@@ -51,11 +51,14 @@ optional columns:
 * `area`  (or `region` or `constituency`)
 * `group` (or `party`, `bloc`, or `faction`)
 
-An optional `group_id` can also be given, if you wish to use predefined
-identifiers, otherwise a unique ID will be allocated.
-
 An optional `start_date` and/or `end_date` can also given for the
 membership.
+
+## ID-generation
+
+It is strongly recommended that `id` and `group_id` columns be provided.
+If not, these will be generated from the `name` (or `group`) column. If
+multiple people have the same name, this will do the wrong thing.
 
 ## Executive Posts
 

--- a/lib/csv_to_popolo/version.rb
+++ b/lib/csv_to_popolo/version.rb
@@ -1,3 +1,3 @@
 module Popolo_CSV
-  VERSION = '0.9.5'
+  VERSION = '0.9.6'
 end

--- a/t/data/broken_empty_headers.csv
+++ b/t/data/broken_empty_headers.csv
@@ -1,4 +1,3 @@
-org,first_name,last_name,twitter,mobile,fax,,wikipedia
-mySociety,Tom,Steinberg,steiny,tomsphone,,http://en.wikipedia.org/wiki/Tom_Steinberg
-Sunlight Foundation,Ellen,Miller,EllnMllr,ellensphone,ellensfax,http://en.wikipedia.org/wiki/Ellen_S._Miller
-,Orgless,,,,,
+org,name,twitter,mobile,fax,,wikipedia
+mySociety,Tom Steinberg,steiny,tomsphone,,http://en.wikipedia.org/wiki/Tom_Steinberg
+Sunlight Foundation,Ellen Miller,EllnMllr,ellensphone,ellensfax,http://en.wikipedia.org/wiki/Ellen_S._Miller

--- a/t/data/tcamp.csv
+++ b/t/data/tcamp.csv
@@ -1,4 +1,4 @@
-org,first_name,last_name,twitter,mobile,fax,wikipedia
-mySociety,Tom,Steinberg,steiny,tomsphone,,http://en.wikipedia.org/wiki/Tom_Steinberg
-Sunlight Foundation,Ellen,Miller,EllnMllr,ellensphone,ellensfax,http://en.wikipedia.org/wiki/Ellen_S._Miller
-,Orgless,,,,,
+org,name,first_name,last_name,twitter,mobile,fax,wikipedia
+mySociety,Tom Steinberg,Tom,Steinberg,steiny,tomsphone,,http://en.wikipedia.org/wiki/Tom_Steinberg
+Sunlight Foundation,Ellen Miller,Ellen,Miller,EllnMllr,ellensphone,ellensfax,http://en.wikipedia.org/wiki/Ellen_S._Miller
+,Orgless,,,,,,

--- a/t/test_empty_headers.rb
+++ b/t/test_empty_headers.rb
@@ -10,6 +10,6 @@ describe 'blank headers' do
   end
 
   it 'should parse the rest fine' do
-    subject.data[:persons].first[:given_name].must_equal 'Tom'
+    subject.data[:persons].first[:name].must_equal 'Tom Steinberg'
   end
 end

--- a/t/test_riigikogu.rb
+++ b/t/test_riigikogu.rb
@@ -26,6 +26,7 @@ describe 'riigikogu' do
 
       party = orgs.find { |o| o[:id] == leg_mem[:on_behalf_of_id] }
       party[:name].must_equal 'Eesti Reformierakonna fraktsioon'
+      party[:id].must_equal 'party/eesti_reformierakonna_fraktsioon'
       party[:classification].must_equal 'party'
     end
 

--- a/t/test_tcamp.rb
+++ b/t/test_tcamp.rb
@@ -62,10 +62,6 @@ describe 'tcamp' do
     let(:orgless) { subject.data[:persons].last }
     let(:mems)    { subject.data[:memberships].select { |m| m[:person_id] == orgless[:id] } }
 
-    it 'should remap the given name' do
-      orgless[:given_name].must_equal 'Orgless'
-    end
-
     it 'should have no family name name' do
       orgless[:family_name].must_be_nil
     end
@@ -87,8 +83,8 @@ describe 'tcamp' do
       ids.uniq.length.must_equal 3
     end
 
-    it 'should give everyone ids of form /person/<hexstring>' do
-      ids.sample.must_match(%r{^person/[[:xdigit:]]+})
+    it 'should generate ids' do
+      ids.first.must_equal 'person/tom_steinberg'
     end
   end
 


### PR DESCRIPTION
Rather than generating unique IDs on every run, IDs are now generated
from the name of the person/party (with a suitable warning that this
may not do what you want if multiple people have the same name)
