### PR TITLE
Handle `area_id`s

### DIFF
--- a/lib/csv_to_popolo.rb
+++ b/lib/csv_to_popolo.rb
@@ -9,6 +9,9 @@ class Popolo
     area: {
       aliases: %w(constituency region district place)
     },
+    area_id: {
+      aliases: %w(constituency_id region_id district_id place_id)
+    },
     biography: {
       aliases: %w(bio blurb),
       type: 'asis'
@@ -255,7 +258,12 @@ class Popolo
           start_date:         r[:start_date],
           end_date:           r[:end_date]
         }.select { |_, v| !v.nil? }
-        mem[:area] = { name: r[:area] } if r.key?(:area) && !r[:area].nil?
+        if (r.key?(:area) && !r[:area].nil?) || (r.key?(:area_id) && !r[:area_id].nil?)
+          mem[:area] = { 
+            id: r[:area_id] || "area/#{_idify(r[:area])}",
+            name: r[:area] || 'unknown'
+          }
+        end
         mem[:legislative_period_id] = "term/#{_idify(r[:term])}" if r.key? :term
         mem
       end

--- a/lib/csv_to_popolo/version.rb
+++ b/lib/csv_to_popolo/version.rb
@@ -1,3 +1,3 @@
 module Popolo_CSV
-  VERSION = '0.9.7'
+  VERSION = '0.9.8'
 end

--- a/t/data/malaysia.csv
+++ b/t/data/malaysia.csv
@@ -1,0 +1,223 @@
+name,state,constituency,wikipedia,party_id,party,term,source,area,coalition,coalition_id,constituency_id
+Zahidi Zainul Abidin,Perlis,Padang Besar,http://en.wikipedia.org/wiki/Zahidi_Zainul_Abidin,UMNO,United Malays National Organisation,13,"","Padang Besar, Perlis",Barisan Nasional,BN,P001
+Shaharuddin Ismail,Perlis,Kangar,http://en.wikipedia.org/wiki/Shaharuddin_Ismail,UMNO,United Malays National Organisation,13,"","Kangar, Perlis",Barisan Nasional,BN,P002
+Shahidan Kassim,Perlis,Arau,http://en.wikipedia.org/wiki/Shahidan_Kassim,UMNO,United Malays National Organisation,13,"","Arau, Perlis",Barisan Nasional,BN,P003
+Nawawi Ahmad,Kedah,Langkawi,http://en.wikipedia.org/wiki/Nawawi_Ahmad,UMNO,United Malays National Organisation,13,"","Langkawi, Kedah",Barisan Nasional,BN,P004
+Othman Aziz,Kedah,Jerlun,http://en.wikipedia.org/wiki/Othman_Aziz,UMNO,United Malays National Organisation,13,"","Jerlun, Kedah",Barisan Nasional,BN,P005
+Mohd Johari Baharum,Kedah,Kubang Pasu,http://en.wikipedia.org/wiki/Mohd_Johari_Baharum,UMNO,United Malays National Organisation,13,"","Kubang Pasu, Kedah",Barisan Nasional,BN,P006
+Mahdzir Khalid,Kedah,Padang Terap,http://en.wikipedia.org/wiki/Mahdzir_Khalid,UMNO,United Malays National Organisation,13,"","Padang Terap, Kedah",Barisan Nasional,BN,P007
+Mahfuz Omar,Kedah,Pokok Sena,http://en.wikipedia.org/wiki/Mahfuz_Omar,PAS,Pan-Malaysian Islamic Party,13,"","Pokok Sena, Kedah",,,P008
+Gooi Hsiao Leung,Kedah,Alor Setar,http://en.wikipedia.org/wiki/Gooi_Hsiao_Leung,PKR,People's Justice Party,13,"","Alor Setar, Kedah",,,P009
+Azman Ismail,Kedah,Kuala Kedah,http://en.wikipedia.org/wiki/Azman_Ismail,PKR,People's Justice Party,13,"","Kuala Kedah, Kedah",,,P010
+Othman Abdul,Kedah,Pendang,http://en.wikipedia.org/wiki/Othman_Abdul,UMNO,United Malays National Organisation,13,"","Pendang, Kedah",Barisan Nasional,BN,P011
+Jamil Khir Baharom,Kedah,Jerai,http://en.wikipedia.org/wiki/Jamil_Khir_Baharom,UMNO,United Malays National Organisation,13,"","Jerai, Kedah",Barisan Nasional,BN,P012
+Mansor Abd Rahman,Kedah,Sik,http://en.wikipedia.org/wiki/Mansor_Abd_Rahman,UMNO,United Malays National Organisation,13,"","Sik, Kedah",Barisan Nasional,BN,P013
+Ismail Daut,Kedah,Merbok,http://en.wikipedia.org/wiki/Ismail_Daut,UMNO,United Malays National Organisation,13,"","Merbok, Kedah",Barisan Nasional,BN,P014
+Johari Abdul,Kedah,Sungai Petani,http://en.wikipedia.org/wiki/Johari_Abdul,PKR,People's Justice Party,13,"","Sungai Petani, Kedah",,,P015
+Abdul Azeez Abdul Rahim,Kedah,Baling,http://en.wikipedia.org/wiki/Abdul_Azeez_Abdul_Rahim,UMNO,United Malays National Organisation,13,"","Baling, Kedah",Barisan Nasional,BN,P016
+Surendran Nagarajan,Kedah,Padang Serai,http://en.wikipedia.org/wiki/N._Surendran,PKR,People's Justice Party,13,"","Padang Serai, Kedah",,,P017
+Abdul Aziz Sheikh Fadzir,Kedah,Kulim-Bandar Baharu,http://en.wikipedia.org/wiki/Abdul_Aziz_Sheikh_Fadzir,UMNO,United Malays National Organisation,13,"","Kulim-Bandar Baharu, Kedah",Barisan Nasional,BN,P018
+Kamaruddin Jaafar,Kelantan,Tumpat,http://en.wikipedia.org/wiki/Kamaruddin_Jaafar,PAS,Pan-Malaysian Islamic Party,13,"","Tumpat, Kelantan",,,P019
+Izani Husin,Kelantan,Pengkalan Chepa,,PAS,Pan-Malaysian Islamic Party,13,"","Pengkalan Chepa, Kelantan",,,P020
+Takiyuddin Hassan,Kelantan,Kota Bharu,,PAS,Pan-Malaysian Islamic Party,13,"","Kota Bharu, Kelantan",,,P021
+Nik Mohamad Abduh Nik Abdul Aziz,Kelantan,Pasir Mas,,PAS,Pan-Malaysian Islamic Party,13,"","Pasir Mas, Kelantan",,,P022
+Siti Zailah Mohd Yusoff,Kelantan,Rantau Panjang,http://en.wikipedia.org/wiki/Siti_Zailah_Mohd_Yusoff,PAS,Pan-Malaysian Islamic Party,13,"","Rantau Panjang, Kelantan",,,P023
+Ahmad Baihaki Atiqullah,Kelantan,Kubang Kerian,,PAS,Pan-Malaysian Islamic Party,13,"","Kubang Kerian, Kelantan",,,P024
+Ahmad Marzuk Shaary,Kelantan,Bachok,,PAS,Pan-Malaysian Islamic Party,13,"","Bachok, Kelantan",,,P025
+Annuar Musa,Kelantan,Ketereh,http://en.wikipedia.org/wiki/Annuar_Musa,UMNO,United Malays National Organisation,13,"","Ketereh, Kelantan",Barisan Nasional,BN,P026
+Ikmal Hisham Abdul Aziz,Kelantan,Tanah Merah,,UMNO,United Malays National Organisation,13,"","Tanah Merah, Kelantan",Barisan Nasional,BN,P027
+Nik Mazian Nik Mohamad,Kelantan,Pasir Puteh,,PAS,Pan-Malaysian Islamic Party,13,"","Pasir Puteh, Kelantan",,,P028
+Ahmad Jazlan Yaakub,Kelantan,Machang,,UMNO,United Malays National Organisation,13,"","Machang, Kelantan",Barisan Nasional,BN,P029
+Mustapa Mohamed,Kelantan,Jeli,http://en.wikipedia.org/wiki/Mustapa_Mohamed,UMNO,United Malays National Organisation,13,"","Jeli, Kelantan",Barisan Nasional,BN,P030
+Mohd Hatta Ramli,Kelantan,Kuala Krai,http://en.wikipedia.org/wiki/Mohd_Hatta_Ramli,PAS,Pan-Malaysian Islamic Party,13,"","Kuala Krai, Kelantan",,,P031
+Tengku Razaleigh Hamzah,Kelantan,Gua Musang,http://en.wikipedia.org/wiki/Tengku_Razaleigh_Hamzah,UMNO,United Malays National Organisation,13,"","Gua Musang, Kelantan",Barisan Nasional,BN,P032
+Idris Jusoh,Terengganu,Besut,http://en.wikipedia.org/wiki/Idris_Jusoh,UMNO,United Malays National Organisation,13,"","Besut, Terengganu",Barisan Nasional,BN,P033
+Che Mohamad Zulkifly Jusoh,Terengganu,Setiu,,UMNO,United Malays National Organisation,13,"","Setiu, Terengganu",Barisan Nasional,BN,P034
+Mohd Khairuddin Aman Razali,Terengganu,Kuala Nerus,,PAS,Pan-Malaysian Islamic Party,13,"","Kuala Nerus, Terengganu",,,P035
+Raja Kamarul Bahrin Shah Raja Ahmad,Terengganu,Kuala Terengganu,,PAS,Pan-Malaysian Islamic Party,13,"","Kuala Terengganu, Terengganu",,,P036
+Abdul Hadi Awang,Terengganu,Marang,http://en.wikipedia.org/wiki/Abdul_Hadi_Awang,PAS,Pan-Malaysian Islamic Party,13,"","Marang, Terengganu",,,P037
+Jailani Johari,Terengganu,Hulu Terengganu,,UMNO,United Malays National Organisation,13,"","Hulu Terengganu, Terengganu",Barisan Nasional,BN,P038
+Wan Hassan Mohd Ramli,Terengganu,Dungun,,PAS,Pan-Malaysian Islamic Party,13,"","Dungun, Terengganu",,,P039
+Ahmad Shabery Cheek,Terengganu,Kemaman,http://en.wikipedia.org/wiki/Ahmad_Shabery_Cheek,UMNO,United Malays National Organisation,13,"","Kemaman, Terengganu",Barisan Nasional,BN,P040
+Reezal Merican Naina Merican,Penang,Kepala Batas,http://en.wikipedia.org/wiki/Reezal_Merican_Naina_Merican,UMNO,United Malays National Organisation,13,"","Kepala Batas, Penang",Barisan Nasional,BN,P041
+Shabudin Yahaya,Penang,Tasek Gelugor,,UMNO,United Malays National Organisation,13,"","Tasek Gelugor, Penang",Barisan Nasional,BN,P042
+Lim Guan Eng,Penang,Bagan,http://en.wikipedia.org/wiki/Lim_Guan_Eng,DAP,Democratic Action Party,13,"","Bagan, Penang",,,P043
+Wan Azizah Wan Ismail,Penang,Permatang Pauh,http://en.wikipedia.org/wiki/Wan_Azizah_Wan_Ismail,PKR,People's Justice Party,13,"","Permatang Pauh, Penang",,,P044
+Steven Sim Chee Keong,Penang,Bukit Mertajam,http://en.wikipedia.org/wiki/Steven_Sim,DAP,Democratic Action Party,13,"","Bukit Mertajam, Penang",,,P045
+Kasthuriraani Patto,Penang,Batu Kawan,http://en.wikipedia.org/wiki/Kasthuriraani_Patto,DAP,Democratic Action Party,13,"","Batu Kawan, Penang",,,P046
+Mansor Othman,Penang,Nibong Tebal,,PKR,People's Justice Party,13,"","Nibong Tebal, Penang",,,P047
+Zairil Khir Johari,Penang,Bukit Bendera,http://en.wikipedia.org/wiki/Zairil_Khir_Johari,DAP,Democratic Action Party,13,"","Bukit Bendera, Penang",,,P048
+Ng Wei Aik,Penang,Tanjong,,DAP,Democratic Action Party,13,"","Tanjong, Penang",,,P049
+Jeff Ooi Chuan Aun,Penang,Jelutong,http://en.wikipedia.org/wiki/Jeff_Ooi,DAP,Democratic Action Party,13,"","Jelutong, Penang",,,P050
+Ramkarpal Singh Deo,Penang,Bukit Gelugor,http://en.wikipedia.org/wiki/Ramkarpal_Singh,DAP,Democratic Action Party,13,"","Bukit Gelugor, Penang",,,P051
+Sim Tze Tzin,Penang,Bayan Baru,http://en.wikipedia.org/wiki/Sim_Tze_Tzin,PKR,People's Justice Party,13,"","Bayan Baru, Penang",,,P052
+Hilmi Yahaya,Penang,Balik Pulau,,UMNO,United Malays National Organisation,13,"","Balik Pulau, Penang",Barisan Nasional,BN,P053
+Hasbullah Osman,Perak,Gerik,,UMNO,United Malays National Organisation,13,"","Gerik, Perak",Barisan Nasional,BN,P054
+Shamsul Anuar Nasarah,Perak,Lenggong,http://en.wikipedia.org/wiki/Shamsul_Anuar_Nasarah,UMNO,United Malays National Organisation,13,"","Lenggong, Perak",Barisan Nasional,BN,P055
+Hamzah Zainudin,Perak,Larut,http://en.wikipedia.org/wiki/Hamzah_Zainudin,UMNO,United Malays National Organisation,13,"","Larut, Perak",Barisan Nasional,BN,P056
+Mujahid Yusof Rawa,Perak,Parit Buntar,http://en.wikipedia.org/wiki/Mujahid_Yusof_Rawa,PAS,Pan-Malaysian Islamic Party,13,"","Parit Buntar, Perak",,,P057
+Noor Azmi Ghazali,Perak,Bagan Serai,,UMNO,United Malays National Organisation,13,"","Bagan Serai, Perak",Barisan Nasional,BN,P058
+Idris Ahmad,Perak,Bukit Gantang,,PAS,Pan-Malaysian Islamic Party,13,"","Bukit Gantang, Perak",,,P059
+Nga Kor Ming,Perak,Taiping,http://en.wikipedia.org/wiki/Nga_Kor_Ming,DAP,Democratic Action Party,13,"","Taiping, Perak",,,P060
+Mohamed Nazri Abdul Aziz,Perak,Padang Rengas,http://en.wikipedia.org/wiki/Mohamed_Nazri_Abdul_Aziz,UMNO,United Malays National Organisation,13,"","Padang Rengas, Perak",Barisan Nasional,BN,P061
+Michael Jeyakumar Devaraj,Perak,Sungai Siput,http://en.wikipedia.org/wiki/Michael_Jeyakumar_Devaraj,PSM,Parti Sosialis Malaysia,13,"","Sungai Siput, Perak",,,P062
+Ahmad Husni Hanadzlah,Perak,Tambun,http://en.wikipedia.org/wiki/Ahmad_Husni_Hanadzlah,UMNO,United Malays National Organisation,13,"","Tambun, Perak",Barisan Nasional,BN,P063
+Su Keong Siong,Perak,Ipoh Timor,,DAP,Democratic Action Party,13,"","Ipoh Timor, Perak",,,P064
+M. Kulasegaran,Perak,Ipoh Barat,http://en.wikipedia.org/wiki/M._Kulasegaran,DAP,Democratic Action Party,13,"","Ipoh Barat, Perak",,,P065
+V. Sivakumar,Perak,Batu Gajah,http://en.wikipedia.org/wiki/V._Sivakumar,DAP,Democratic Action Party,13,"","Batu Gajah, Perak",,,P066
+Wan Mohammad Khair-il Anuar Wan Ahmad,Perak,Kuala Kangsar,http://en.wikipedia.org/wiki/Wan_Mohammad_Khair-il_Anuar_Wan_Ahmad,UMNO,United Malays National Organisation,13,"","Kuala Kangsar, Perak",Barisan Nasional,BN,P067
+Ngeh Koo Ham,Perak,Beruas,http://en.wikipedia.org/wiki/Ngeh_Koo_Ham,DAP,Democratic Action Party,13,"","Beruas, Perak",,,P068
+Mohd Zaim Abu Hassan,Perak,Parit,,UMNO,United Malays National Organisation,13,"","Parit, Perak",Barisan Nasional,BN,P069
+Ko Chung Sen,Perak,Kampar,,DAP,Democratic Action Party,13,"","Kampar, Perak",,,P070
+Lee Boon Chye,Perak,Gopeng,http://en.wikipedia.org/wiki/Lee_Boon_Chye,PKR,People's Justice Party,13,"","Gopeng, Perak",,,P071
+Saravanan Murugan,Perak,Tapah,http://en.wikipedia.org/wiki/Saravanan_Murugan,MIC,Malaysian Indian Congress,13,"","Tapah, Perak",Barisan Nasional,BN,P072
+Tajuddin Abdul Rahman,Perak,Pasir Salak,http://en.wikipedia.org/wiki/Tajuddin_Abdul_Rahman,UMNO,United Malays National Organisation,13,"","Pasir Salak, Perak",Barisan Nasional,BN,P073
+Mohamad Imran Abd Hamid,Perak,Lumut,,PKR,People's Justice Party,13,"","Lumut, Perak",,,P074
+Ahmad Zahid Hamidi,Perak,Bagan Datok,http://en.wikipedia.org/wiki/Ahmad_Zahid_Hamidi,UMNO,United Malays National Organisation,13,"","Bagan Datok, Perak",Barisan Nasional,BN,P075
+Mah Siew Keong,Perak,Telok Intan,,Gerakan,Parti Gerakan Rakyat Malaysia,13,"","Telok Intan, Perak",Barisan Nasional,BN,P076
+Ong Ka Chuan,Perak,Tanjong Malim,http://en.wikipedia.org/wiki/Ong_Ka_Chuan,MCA,Malaysian Chinese Association,13,"","Tanjong Malim, Perak",Barisan Nasional,BN,P077
+Palanivel Govindasamy,Pahang,Cameron Highlands,http://en.wikipedia.org/wiki/Palanivel_Govindasamy,MIC,Malaysian Indian Congress,13,"","Cameron Highlands, Pahang",Barisan Nasional,BN,P078
+Abdul Rahman Mohamad,Pahang,Lipis,,UMNO,United Malays National Organisation,13,"","Lipis, Pahang",Barisan Nasional,BN,P079
+Mohd Ariff Sabri Abdul Aziz,Pahang,Raub,http://en.wikipedia.org/wiki/Ariff_Sabri_Abdul_Aziz,DAP,Democratic Action Party,13,"","Raub, Pahang",,,P080
+Ahmad Nazlan Idris,Pahang,Jerantut,,UMNO,United Malays National Organisation,13,"","Jerantut, Pahang",Barisan Nasional,BN,P081
+Fauzi Abdul Rahman,Pahang,Indera Mahkota,,PKR,People's Justice Party,13,"","Indera Mahkota, Pahang",,,P082
+Fuziah Salleh,Pahang,Kuantan,http://en.wikipedia.org/wiki/Fuziah_Salleh,PKR,People's Justice Party,13,"","Kuantan, Pahang",,,P083
+Abdul Manan Ismail,Pahang,Paya Besar,http://en.wikipedia.org/wiki/Abdul_Manan_Ismail,UMNO,United Malays National Organisation,13,"","Paya Besar, Pahang",Barisan Nasional,BN,P084
+Najib Razak,Pahang,Pekan,http://en.wikipedia.org/wiki/Najib_Razak,UMNO,United Malays National Organisation,13,"","Pekan, Pahang",Barisan Nasional,BN,P085
+Ismail Muttalib,Pahang,Maran,http://en.wikipedia.org/wiki/Ismail_Muttalib,UMNO,United Malays National Organisation,13,"","Maran, Pahang",Barisan Nasional,BN,P086
+Ismail Mohamed Said,Pahang,Kuala Krau,http://en.wikipedia.org/wiki/Ismail_Mohamed_Said,UMNO,United Malays National Organisation,13,"","Kuala Krau, Pahang",Barisan Nasional,BN,P087
+Nasrudin Hassan,Pahang,Temerloh,,PAS,Pan-Malaysian Islamic Party,13,"","Temerloh, Pahang",,,P088
+Liow Tiong Lai,Pahang,Bentong,http://en.wikipedia.org/wiki/Liow_Tiong_Lai,MCA,Malaysian Chinese Association,13,"","Bentong, Pahang",Barisan Nasional,BN,P089
+Ismail Sabri Yaakob,Pahang,Bera,http://en.wikipedia.org/wiki/Ismail_Sabri_Yaakob,UMNO,United Malays National Organisation,13,"","Bera, Pahang",Barisan Nasional,BN,P090
+Hasan Arifin,Pahang,Rompin,,UMNO,United Malays National Organisation,13,"","Rompin, Pahang",Barisan Nasional,BN,P091
+Mohd Fasiah Mohd Fakeh,Selangor,Sabak Bernam,,UMNO,United Malays National Organisation,13,"","Sabak Bernam, Selangor",Barisan Nasional,BN,P092
+Noriah Kasnon,Selangor,Sungai Besar,http://en.wikipedia.org/wiki/Noriah_Kasnon,UMNO,United Malays National Organisation,13,"","Sungai Besar, Selangor",Barisan Nasional,BN,P093
+Kamalanathan Panchanathan,Selangor,Hulu Selangor,http://en.wikipedia.org/wiki/P._Kamalanathan,MIC,Malaysian Indian Congress,13,"","Hulu Selangor, Selangor",Barisan Nasional,BN,P094
+Noh Omar,Selangor,Tanjong Karang,http://en.wikipedia.org/wiki/Noh_Omar,UMNO,United Malays National Organisation,13,"","Tanjong Karang, Selangor",Barisan Nasional,BN,P095
+Irmohizan Ibrahim,Selangor,Kuala Selangor,,UMNO,United Malays National Organisation,13,"","Kuala Selangor, Selangor",Barisan Nasional,BN,P096
+William Leong Jee Keen,Selangor,Selayang,http://en.wikipedia.org/wiki/William_Leong_Jee_Keen,PKR,People's Justice Party,13,"","Selayang, Selangor",,,P097
+Mohamed Azmin Ali,Selangor,Gombak,http://en.wikipedia.org/wiki/Mohamed_Azmin_Ali,PKR,People's Justice Party,13,"","Gombak, Selangor",,,P098
+Zuraida Kamarudin,Selangor,Ampang,http://en.wikipedia.org/wiki/Zuraida_Kamarudin,PKR,People's Justice Party,13,"","Ampang, Selangor",,,P099
+Rafizi Ramli,Selangor,Pandan,http://en.wikipedia.org/wiki/Rafizi_Ramli,PKR,People's Justice Party,13,"","Pandan, Selangor",,,P100
+Che Rosli Che Mat,Selangor,Hulu Langat,http://en.wikipedia.org/wiki/Che_Rosli_Che_Mat,PAS,Pan-Malaysian Islamic Party,13,"","Hulu Langat, Selangor",,,P101
+Ong Kian Ming,Selangor,Serdang,http://en.wikipedia.org/wiki/Ong_Kian_Ming,DAP,Democratic Action Party,13,"","Serdang, Selangor",,,P102
+Gobind Singh Deo,Selangor,Puchong,http://en.wikipedia.org/wiki/Gobind_Singh_Deo,DAP,Democratic Action Party,13,"","Puchong, Selangor",,,P103
+Wong Chen,Selangor,Kelana Jaya,http://en.wikipedia.org/wiki/Wong_Chen,PKR,People's Justice Party,13,"","Kelana Jaya, Selangor",,,P104
+Hee Loy Sian,Selangor,Petaling Jaya Selatan,http://en.wikipedia.org/wiki/Hee_Loy_Sian,PKR,People's Justice Party,13,"","Petaling Jaya Selatan, Selangor",,,P105
+Tony Pua Kiam Wee,Selangor,Petaling Jaya Utara,http://en.wikipedia.org/wiki/Tony_Pua,DAP,Democratic Action Party,13,"","Petaling Jaya Utara, Selangor",,,P106
+Sivarasa K. Rasiah,Selangor,Subang,http://en.wikipedia.org/wiki/Sivarasa_Rasiah,PKR,People's Justice Party,13,"","Subang, Selangor",,,P107
+Khalid Samad,Selangor,Shah Alam,http://en.wikipedia.org/wiki/Khalid_Samad,PAS,Pan-Malaysian Islamic Party,13,"","Shah Alam, Selangor",,,P108
+Manivannan Gowindasamy,Selangor,Kapar,,PKR,People's Justice Party,13,"","Kapar, Selangor",,,P109
+Charles Anthony R. Santiago,Selangor,Klang,http://en.wikipedia.org/wiki/Charles_Santiago,DAP,Democratic Action Party,13,"","Klang, Selangor",,,P110
+Siti Mariah Mahmud,Selangor,Kota Raja,http://en.wikipedia.org/wiki/Siti_Mariah_Mahmud,PAS,Pan-Malaysian Islamic Party,13,"","Kota Raja, Selangor",,,P111
+Abdullah Sani Abdul Hamid,Selangor,Kuala Langat,http://en.wikipedia.org/wiki/Abdullah_Sani_Abdul_Hamid,PKR,People's Justice Party,13,"","Kuala Langat, Selangor",,,P112
+Mohamed Hanipa Maidin,Selangor,Sepang,,PAS,Pan-Malaysian Islamic Party,13,"","Sepang, Selangor",,,P113
+Tan Seng Giaw,Federal Territory of Kuala Lumpur,Kepong,http://en.wikipedia.org/wiki/Tan_Seng_Giaw,DAP,Democratic Action Party,13,"","Kepong, Federal Territory of Kuala Lumpur",,,P114
+Chua Tian Chang,Federal Territory of Kuala Lumpur,Batu,http://en.wikipedia.org/wiki/Chua_Tian_Chang,PKR,People's Justice Party,13,"","Batu, Federal Territory of Kuala Lumpur",,,P115
+Tan Kee Kwong,Federal Territory of Kuala Lumpur,Wangsa Maju,,PKR,People's Justice Party,13,"","Wangsa Maju, Federal Territory of Kuala Lumpur",,,P116
+Lim Lip Eng,Federal Territory of Kuala Lumpur,Segambut,http://en.wikipedia.org/wiki/Lim_Lip_Eng,DAP,People's Justice Party,13,"","Segambut, Federal Territory of Kuala Lumpur",,,P117
+Ahmad Fauzi Zahari,Federal Territory of Kuala Lumpur,Setiawangsa,,UMNO,United Malays National Organisation,13,"","Setiawangsa, Federal Territory of Kuala Lumpur",Barisan Nasional,BN,P118
+Johari Abdul Ghani,Federal Territory of Kuala Lumpur,Titiwangsa,http://en.wikipedia.org/wiki/Johari_Abdul_Ghani,UMNO,United Malays National Organisation,13,"","Titiwangsa, Federal Territory of Kuala Lumpur",Barisan Nasional,BN,P119
+Fong Kui Lun,Federal Territory of Kuala Lumpur,Bukit Bintang,http://en.wikipedia.org/wiki/Fong_Kui_Lun,DAP,Democratic Action Party,13,"","Bukit Bintang, Federal Territory of Kuala Lumpur",,,P120
+Nurul Izzah Anwar,Federal Territory of Kuala Lumpur,Lembah Pantai,http://en.wikipedia.org/wiki/Nurul_Izzah_Anwar,PKR,People's Justice Party,13,"","Lembah Pantai, Federal Territory of Kuala Lumpur",,,P121
+Teresa Kok Suh Sim,Federal Territory of Kuala Lumpur,Seputeh,http://en.wikipedia.org/wiki/Teresa_Kok,DAP,Democratic Action Party,13,"","Seputeh, Federal Territory of Kuala Lumpur",,,P122
+Tan Kok Wai,Federal Territory of Kuala Lumpur,Cheras,http://en.wikipedia.org/wiki/Tan_Kok_Wai,DAP,Democratic Action Party,13,"","Cheras, Federal Territory of Kuala Lumpur",,,P123
+Abdul Khalid Ibrahim,Federal Territory of Kuala Lumpur,Bandar Tun Razak,http://en.wikipedia.org/wiki/Abdul_Khalid_Ibrahim,IND,Independent,13,"","Bandar Tun Razak, Federal Territory of Kuala Lumpur",,,P124
+Tengku Adnan Tengku Mansor,Federal Territory of Putrajaya,Putrajaya,http://en.wikipedia.org/wiki/Tengku_Adnan_Tengku_Mansor,UMNO,United Malays National Organisation,13,"","Putrajaya, Federal Territory of Putrajaya",Barisan Nasional,BN,P125
+Zainudin Ismail,Negeri Sembilan,Jelebu,,UMNO,United Malays National Organisation,13,"","Jelebu, Negeri Sembilan",Barisan Nasional,BN,P126
+Mohd Isa Abdul Samad,Negeri Sembilan,Jempol,,UMNO,United Malays National Organisation,13,"","Jempol, Negeri Sembilan",Barisan Nasional,BN,P127
+Loke Siew Fook,Negeri Sembilan,Seremban,http://en.wikipedia.org/wiki/Loke_Siew_Fook,DAP,Democratic Action Party,13,"","Seremban, Negeri Sembilan",,,P128
+Hasan Malek,Negeri Sembilan,Kuala Pilah,http://en.wikipedia.org/wiki/Hasan_Malek,UMNO,United Malays National Organisation,13,"","Kuala Pilah, Negeri Sembilan",Barisan Nasional,BN,P129
+Teo Kok Seong,Negeri Sembilan,Rasah,,DAP,Democratic Action Party,13,"","Rasah, Negeri Sembilan",,,P130
+Khairy Jamaluddin Abu Bakar,Negeri Sembilan,Rembau,http://en.wikipedia.org/wiki/Khairy_Jamaluddin,UMNO,United Malays National Organisation,13,"","Rembau, Negeri Sembilan",Barisan Nasional,BN,P131
+Kamarul Baharin Abbas,Negeri Sembilan,Telok Kemang,http://en.wikipedia.org/wiki/Kamarul_Baharin_Abbas,PKR,People's Justice Party,13,"","Telok Kemang, Negeri Sembilan",,,P132
+Shaziman Abu Mansor,Negeri Sembilan,Tampin,http://en.wikipedia.org/wiki/Shaziman_Abu_Mansor,UMNO,United Malays National Organisation,13,"","Tampin, Negeri Sembilan",Barisan Nasional,BN,P133
+Mas Ermieyati Samsudin,Malacca,Masjid Tanah,,UMNO,United Malays National Organisation,13,"","Masjid Tanah, Malacca",Barisan Nasional,BN,P134
+Koh Nai Kwong,Malacca,Alor Gajah,http://en.wikipedia.org/wiki/Koh_Nai_Kwong,MCA,Malaysian Chinese Association,13,"","Alor Gajah, Malacca",Barisan Nasional,BN,P135
+Abu Bakar Mohamad Diah,Malacca,Tangga Batu,,UMNO,United Malays National Organisation,13,"","Tangga Batu, Malacca",Barisan Nasional,BN,P136
+Shamsul Iskandar Md. Akin,Malacca,Bukit Katil,http://en.wikipedia.org/wiki/Shamsul_Iskandar_Md._Akin,PKR,People's Justice Party,13,"","Bukit Katil, Malacca",,,P137
+Sim Tong Him,Malacca,Kota Melaka,http://en.wikipedia.org/wiki/Sim_Tong_Him,DAP,Democratic Action Party,13,"","Kota Melaka, Malacca",,,P138
+Ahmad Hamzah,Malacca,Jasin,http://en.wikipedia.org/wiki/Ahmad_Hamzah,UMNO,United Malays National Organisation,13,"","Jasin, Malacca",Barisan Nasional,BN,P139
+Subramaniam Sathasivam,Johor,Segamat,http://en.wikipedia.org/wiki/Subramaniam_Sathasivam,MIC,Malaysian Indian Congress,13,"","Segamat, Johor",Barisan Nasional,BN,P140
+Anuar Abd. Manap,Johor,Sekijang,,UMNO,United Malays National Organisation,13,"","Sekijang, Johor",Barisan Nasional,BN,P141
+Chua Tee Yong,Johor,Labis,http://en.wikipedia.org/wiki/Chua_Tee_Yong,MCA,Malaysian Chinese Association,13,"","Labis, Johor",Barisan Nasional,BN,P142
+Muhyiddin Yassin,Johor,Pagoh,http://en.wikipedia.org/wiki/Muhyiddin_Yassin,UMNO,United Malays National Organisation,13,"","Pagoh, Johor",Barisan Nasional,BN,P143
+Hamim Samuri,Johor,Ledang,http://en.wikipedia.org/wiki/Hamim_Samuri,UMNO,United Malays National Organisation,13,"","Ledang, Johor",Barisan Nasional,BN,P144
+Er Teck Hwa,Johor,Bakri,http://en.wikipedia.org/wiki/Er_Teck_Hwa,DAP,Democratic Action Party,13,"","Bakri, Johor",,,P145
+Razali Ibrahim,Johor,Muar,http://en.wikipedia.org/wiki/Razali_Ibrahim,UMNO,United Malays National Organisation,13,"","Muar, Johor",Barisan Nasional,BN,P146
+Noraini Ahmad,Johor,Parit Sulong,http://en.wikipedia.org/wiki/Noraini_Ahmad,UMNO,United Malays National Organisation,13,"","Parit Sulong, Johor",Barisan Nasional,BN,P147
+Wee Ka Siong,Johor,Ayer Hitam,http://en.wikipedia.org/wiki/Wee_Ka_Siong,MCA,Malaysian Chinese Association,13,"","Ayer Hitam, Johor",Barisan Nasional,BN,P148
+Aziz Kaprawi,Johor,Sri Gading,http://en.wikipedia.org/wiki/Aziz_Kaprawi,UMNO,United Malays National Organisation,13,"","Sri Gading, Johor",Barisan Nasional,BN,P149
+Mohd Idris Jusi,Johor,Batu Pahat,http://en.wikipedia.org/wiki/Mohd_Idris_Jusi,PKR,People's Justice Party,13,"","Batu Pahat, Johor",,,P150
+Liang Teck Meng,Johor,Simpang Renggam,http://en.wikipedia.org/wiki/Liang_Teck_Meng,Gerakan,Parti Gerakan Rakyat Malaysia,13,"","Simpang Renggam, Johor",Barisan Nasional,BN,P151
+Liew Chin Tong,Johor,Kluang,http://en.wikipedia.org/wiki/Liew_Chin_Tong,DAP,Democratic Action Party,13,"","Kluang, Johor",,,P152
+Hishammuddin Hussein,Johor,Sembrong,http://en.wikipedia.org/wiki/Hishammuddin_Hussein,UMNO,United Malays National Organisation,13,"","Sembrong, Johor",Barisan Nasional,BN,P153
+Abdul Latiff Ahmad,Johor,Mersing,http://en.wikipedia.org/wiki/Abdul_Latiff_Ahmad,UMNO,United Malays National Organisation,13,"","Mersing, Johor",Barisan Nasional,BN,P154
+Halimah Mohd Sadique,Johor,Tenggara,http://en.wikipedia.org/wiki/Halimah_Mohd_Sadique,UMNO,United Malays National Organisation,13,"","Tenggara, Johor",Barisan Nasional,BN,P155
+Noor Ehsanuddin Mohd Harun Narrashid,Johor,Kota Tinggi,http://en.wikipedia.org/wiki/Noor_Ehsanuddin_Mohd_Harun_Narrashid,UMNO,United Malays National Organisation,13,"","Kota Tinggi, Johor",Barisan Nasional,BN,P156
+Azalina Othman Said,Johor,Pengerang,http://en.wikipedia.org/wiki/Azalina_Othman_Said,UMNO,United Malays National Organisation,13,"","Pengerang, Johor",Barisan Nasional,BN,P157
+Khoo Soo Seang,Johor,Tebrau,,MCA,Malaysian Chinese Association,13,"","Tebrau, Johor",Barisan Nasional,BN,P158
+Normala Abdul Samad,Johor,Pasir Gudang,http://en.wikipedia.org/wiki/Normala_Abdul_Samad,UMNO,United Malays National Organisation,13,"","Pasir Gudang, Johor",Barisan Nasional,BN,P159
+Shahrir Abdul Samad,Johor,Johor Bahru,http://en.wikipedia.org/wiki/Shahrir_Abdul_Samad,UMNO,United Malays National Organisation,13,"","Johor Bahru, Johor",Barisan Nasional,BN,P160
+Nur Jazlan Mohamed,Johor,Pulai,http://en.wikipedia.org/wiki/Nur_Jazlan_Mohamed,UMNO,United Malays National Organisation,13,"","Pulai, Johor",Barisan Nasional,BN,P161
+Lim Kit Siang,Johor,Gelang Patah,http://en.wikipedia.org/wiki/Lim_Kit_Siang,DAP,Democratic Action Party,13,"","Gelang Patah, Johor",,,P162
+Teo Nie Ching,Johor,Kulai,http://en.wikipedia.org/wiki/Teo_Nie_Ching,DAP,Democratic Action Party,13,"","Kulai, Johor",,,P163
+Ahmad Maslan,Johor,Pontian,http://en.wikipedia.org/wiki/Ahmad_Maslan,UMNO,United Malays National Organisation,13,"","Pontian, Johor",Barisan Nasional,BN,P164
+Wee Jeck Seng,Johor,Tanjong Piai,http://en.wikipedia.org/wiki/Wee_Jeck_Seng,MCA,Malaysian Chinese Association,13,"","Tanjong Piai, Johor",Barisan Nasional,BN,P165
+Rozman Isli,Federal Territory of Labuan,Labuan,,UMNO,United Malays National Organisation,13,"","Labuan, Federal Territory of Labuan",Barisan Nasional,BN,P166
+Abdul Rahim Bakri,Sabah,Kudat,http://en.wikipedia.org/wiki/Abdul_Rahim_Bakri,UMNO,Pertubuhan Kebangsaan Melayu Bersatu,13,"","Kudat, Sabah",Barisan Nasional,BN,P167
+Maximus Johnity Ongkili,Sabah,Kota Marudu,http://en.wikipedia.org/wiki/Maximus_Ongkili,PBS,Parti Bersatu Sabah,13,"","Kota Marudu, Sabah",Barisan Nasional,BN,P168
+Abdul Rahman Dahlan,Sabah,Kota Belud,http://en.wikipedia.org/wiki/Abdul_Rahman_Dahlan,UMNO,Pertubuhan Kebangsaan Melayu Bersatu,13,"","Kota Belud, Sabah",Barisan Nasional,BN,P169
+Madius Tangau,Sabah,Tuaran,,UPKO,United Pasokmomogun Kadazandusun Murut Organisation,13,"","Tuaran, Sabah",Barisan Nasional,BN,P170
+Jumat Idris,Sabah,Sepanggar,,UMNO,Pertubuhan Kebangsaan Melayu Bersatu,13,"","Sepanggar, Sabah",Barisan Nasional,BN,P171
+Jimmy Wong Sze Phin,Sabah,Kota Kinabalu,http://en.wikipedia.org/wiki/Wong_Sze_Phin,DAP,Democratic Action Party,13,"","Kota Kinabalu, Sabah",,,P172
+Marcus Mojigoh,Sabah,Putatan,http://en.wikipedia.org/wiki/Marcus_Mojigoh,UPKO,United Pasokmomogun Kadazandusun Murut Organisation,13,"","Putatan, Sabah",Barisan Nasional,BN,P173
+Ignatius Dorrel Leiking,Sabah,Penampang,,PKR,People's Justice Party,13,"","Penampang, Sabah",,,P174
+Rosnah Abdul Rashid Shirlin,Sabah,Papar,http://en.wikipedia.org/wiki/Rosnah_Shirlin,UMNO,Pertubuhan Kebangsaan Melayu Bersatu,13,"","Papar, Sabah",Barisan Nasional,BN,P175
+Anifah Aman,Sabah,Kimanis,http://en.wikipedia.org/wiki/Anifah_Aman,UMNO,Pertubuhan Kebangsaan Melayu Bersatu,13,"","Kimanis, Sabah",Barisan Nasional,BN,P176
+Azizah Mohd Dun,Sabah,Beaufort,http://en.wikipedia.org/wiki/Azizah_Mohd_Dun,UMNO,Pertubuhan Kebangsaan Melayu Bersatu,13,"","Beaufort, Sabah",Barisan Nasional,BN,P177
+Sapawi Ahmad,Sabah,Sipitang,http://en.wikipedia.org/wiki/Sapawi_Ahmad,UMNO,Pertubuhan Kebangsaan Melayu Bersatu,13,"","Sipitang, Sabah",Barisan Nasional,BN,P178
+Ewon Ebin,Sabah,Ranau,,UPKO,United Pasokmomogun Kadazandusun Murut Organisation,13,"","Ranau, Sabah",Barisan Nasional,BN,P179
+Joseph Pairin Kitingan,Sabah,Keningau,http://en.wikipedia.org/wiki/Joseph_Pairin_Kitingan,PBS,Parti Bersatu Sabah,13,"","Keningau, Sabah",Barisan Nasional,BN,P180
+Raime Unggi,Sabah,Tenom,http://en.wikipedia.org/wiki/Raime_Unggi,UMNO,Pertubuhan Kebangsaan Melayu Bersatu,13,"","Tenom, Sabah",Barisan Nasional,BN,P181
+Joseph Kurup,Sabah,Pensiangan,http://en.wikipedia.org/wiki/Joseph_Kurup,PBRS,Parti Bersatu Rakyat Sabah,13,"","Pensiangan, Sabah",Barisan Nasional,BN,P182
+Ronald Kiandee,Sabah,Beluran,http://en.wikipedia.org/wiki/Ronald_Kiandee,UMNO,Pertubuhan Kebangsaan Melayu Bersatu,13,"","Beluran, Sabah",Barisan Nasional,BN,P183
+Juslie Ajirol,Sabah,Libaran,http://en.wikipedia.org/wiki/Juslie_Ajirol,UMNO,Pertubuhan Kebangsaan Melayu Bersatu,13,"","Libaran, Sabah",Barisan Nasional,BN,P184
+Linda Tsen Thau Lin,Sabah,Batu Sapi,http://en.wikipedia.org/wiki/Linda_Tsen,PBS,Parti Bersatu Sabah,13,"","Batu Sapi, Sabah",Barisan Nasional,BN,P185
+Wong Tien Fatt,Sabah,Sandakan,,DAP,Democratic Action Party,13,"","Sandakan, Sabah",,,P186
+Bung Moktar Radin,Sabah,Kinabatangan,http://en.wikipedia.org/wiki/Bung_Moktar_Radin,UMNO,Pertubuhan Kebangsaan Melayu Bersatu,13,"","Kinabatangan, Sabah",Barisan Nasional,BN,P187
+Nasrun Mansor,Sabah,Silam,,UMNO,Pertubuhan Kebangsaan Melayu Bersatu,13,"","Silam, Sabah",Barisan Nasional,BN,P188
+Mohd Shafie Apdal,Sabah,Semporna,http://en.wikipedia.org/wiki/Shafie_Apdal,UMNO,Pertubuhan Kebangsaan Melayu Bersatu,13,"","Semporna, Sabah",Barisan Nasional,BN,P189
+Mary Yap Kain Ching,Sabah,Tawau,,PBS,Parti Bersatu Sabah,13,"","Tawau, Sabah",Barisan Nasional,BN,P190
+Abdul Ghapur Salleh,Sabah,Kalabakan,http://en.wikipedia.org/wiki/Abdul_Ghapur_Salleh,UMNO,Pertubuhan Kebangsaan Melayu Bersatu,13,"","Kalabakan, Sabah",Barisan Nasional,BN,P191
+Nogeh Gumbek,Sarawak,Mas Gading,,SPDP,Sarawak Progressive Democratic Party,13,"","Mas Gading, Sarawak",Barisan Nasional,BN,P192
+Wan Junaidi Tuanku Jaafar,Sarawak,Santubong,http://en.wikipedia.org/wiki/Wan_Junaidi_Tuanku_Jaafar,PBB,Parti Pesaka Bumiputera Bersatu,13,"","Santubong, Sarawak",Barisan Nasional,BN,P193
+Fadillah Yusof,Sarawak,Petra Jaya,http://en.wikipedia.org/wiki/Fadillah_Yusof,PBB,Parti Pesaka Bumiputera Bersatu,13,"","Petra Jaya, Sarawak",Barisan Nasional,BN,P194
+Chong Chieng Jen,Sarawak,Bandar Kuching,http://en.wikipedia.org/wiki/Chong_Chieng_Jen,DAP,Democratic Action Party,13,"","Bandar Kuching, Sarawak",,,P195
+Julian Tan Kok Ping,Sarawak,Stampin,http://en.wikipedia.org/wiki/Julian_Tan_Kok_Ping,DAP,Democratic Action Party,13,"","Stampin, Sarawak",,,P196
+Rubiah Wang,Sarawak,Kota Samarahan,http://en.wikipedia.org/wiki/Rubiah_Wang,PBB,Parti Pesaka Bumiputera Bersatu,13,"","Kota Samarahan, Sarawak",Barisan Nasional,BN,P197
+James Dawos Mamit,Sarawak,Mambong,http://en.wikipedia.org/wiki/James_Dawos_Mamit,PBB,Parti Pesaka Bumiputera Bersatu,13,"","Mambong, Sarawak",Barisan Nasional,BN,P198
+Richard Riot Jaem,Sarawak,Serian,http://en.wikipedia.org/wiki/Richard_Riot_Jaem,SUPP,Sarawak United Peoples' Party,13,"","Serian, Sarawak",Barisan Nasional,BN,P199
+Nancy Shukri,Sarawak,Batang Sadong,http://en.wikipedia.org/wiki/Nancy_Shukri,PBB,Parti Pesaka Bumiputera Bersatu,13,"","Batang Sadong, Sarawak",Barisan Nasional,BN,P200
+Rohani Abdul Karim,Sarawak,Batang Lupar,http://en.wikipedia.org/wiki/Rohani_Abdul_Karim,PBB,Parti Pesaka Bumiputera Bersatu,13,"","Batang Lupar, Sarawak",Barisan Nasional,BN,P201
+Masir Kujat,Sarawak,Sri Aman,http://en.wikipedia.org/wiki/Masir_Kujat,PRS,Parti Rakyat Sarawak,13,"","Sri Aman, Sarawak",Barisan Nasional,BN,P202
+William Nyallau Badak,Sarawak,Lubok Antu,http://en.wikipedia.org/wiki/William_Nyallau_Badak,PRS,Parti Rakyat Sarawak,13,"","Lubok Antu, Sarawak",Barisan Nasional,BN,P203
+Douglas Uggah Embas,Sarawak,Betong,http://en.wikipedia.org/wiki/Douglas_Uggah_Embas,PBB,Parti Pesaka Bumiputera Bersatu,13,"","Betong, Sarawak",Barisan Nasional,BN,P204
+William Mawan Ikom,Sarawak,Saratok,,TERAS,Parti Tenaga Rakyat Sarawak,13,"","Saratok, Sarawak",,,P205
+Norah Abdul Rahman,Sarawak,Tanjong Manis,http://en.wikipedia.org/wiki/Norah_Abdul_Rahman,PBB,Parti Pesaka Bumiputera Bersatu,13,"","Tanjong Manis, Sarawak",Barisan Nasional,BN,P206
+Wahab Dolah,Sarawak,Igan,http://en.wikipedia.org/wiki/Wahab_Dolah,PBB,Parti Pesaka Bumiputera Bersatu,13,"","Igan, Sarawak",Barisan Nasional,BN,P207
+Wong Ling Biu,Sarawak,Sarikei,,DAP,Democratic Action Party,13,"","Sarikei, Sarawak",,,P208
+Joseph Salang Gandum,Sarawak,Julau,http://en.wikipedia.org/wiki/Joseph_Salang_Gandum,PRS,Parti Rakyat Sarawak,13,"","Julau, Sarawak",Barisan Nasional,BN,P209
+Aaron Ago Dagang,Sarawak,Kanowit,http://en.wikipedia.org/wiki/Aaron_Ago_Dagang,PRS,Parti Rakyat Sarawak,13,"","Kanowit, Sarawak",Barisan Nasional,BN,P210
+Alice Lau Kiong Yieng,Sarawak,Lanang,,DAP,Democratic Action Party,13,"","Lanang, Sarawak",,,P211
+Oscar Ling Chai Yew,Sarawak,Sibu,,DAP,Democratic Action Party,13,"","Sibu, Sarawak",,,P212
+Leo Michael Toyad,Sarawak,Mukah,http://en.wikipedia.org/wiki/Leo_Michael_Toyad,PBB,Parti Pesaka Bumiputera Bersatu,13,"","Mukah, Sarawak",Barisan Nasional,BN,P213
+Joseph Entulu Belaun,Sarawak,Selangau,http://en.wikipedia.org/wiki/Joseph_Entulu_Belaun,PRS,Parti Rakyat Sarawak,13,"","Selangau, Sarawak",Barisan Nasional,BN,P214
+Alexander Nanta Linggi,Sarawak,Kapit,http://en.wikipedia.org/wiki/Alexander_Nanta_Linggi,PBB,Parti Pesaka Bumiputera Bersatu,13,"","Kapit, Sarawak",Barisan Nasional,BN,P215
+Wilson Ugak Kumbong,Sarawak,Hulu Rajang,,PRS,Parti Rakyat Sarawak,13,"","Hulu Rajang, Sarawak",Barisan Nasional,BN,P216
+Tiong King Sing,Sarawak,Bintulu,http://en.wikipedia.org/wiki/Tiong_King_Sing,SPDP,Sarawak Progressive Democratic Party,13,"","Bintulu, Sarawak",Barisan Nasional,BN,P217
+Ahmad Lai Bujang,Sarawak,Sibuti,http://en.wikipedia.org/wiki/Ahmad_Lai_Bujang,PBB,Parti Pesaka Bumiputera Bersatu,13,"","Sibuti, Sarawak",Barisan Nasional,BN,P218
+Michael Teo Yu Keng,Sarawak,Miri,,PKR,People's Justice Party,13,"","Miri, Sarawak",,,P219
+Anyi Ngau,Sarawak,Baram,,SPDP,Sarawak Progressive Democratic Party,13,"","Baram, Sarawak",Barisan Nasional,BN,P220
+Hasbi Habibollah,Sarawak,Limbang,http://en.wikipedia.org/wiki/Hasbi_Habibollah,PBB,Parti Pesaka Bumiputera Bersatu,13,"","Limbang, Sarawak",Barisan Nasional,BN,P221
+Henry Sum Agong,Sarawak,Lawas,http://en.wikipedia.org/wiki/Henry_Sum_Agong,PBB,Parti Pesaka Bumiputera Bersatu,13,"","Lawas, Sarawak",Barisan Nasional,BN,P222

--- a/t/test_area_ids.rb
+++ b/t/test_area_ids.rb
@@ -1,0 +1,25 @@
+
+require 'csv_to_popolo'
+require 'minitest/autorun'
+require 'json'
+
+describe 'Bhutan' do
+  subject { Popolo::CSV.new('t/data/malaysia.csv') }
+
+  let(:ppl)  { subject.data[:persons] }
+  let(:orgs) { subject.data[:organizations] }
+  let(:mems) { subject.data[:memberships] }
+  let(:legm) { mems.select { |m| m[:role] == 'member' } }
+
+  describe 'Shaharuddin Ismail' do
+    it 'should have one legislative membership' do
+      legm.count { |m| m[:person_id] == 'person/shaharuddin_ismail' }.must_equal 1
+    end
+
+    it 'should have a source' do
+      lm = legm.find { |m| m[:person_id] == 'person/shaharuddin_ismail' }
+      lm[:area][:name].must_equal 'Kangar, Perlis'
+      lm[:area][:id].must_equal 'P002'
+    end
+  end
+end

--- a/t/test_parlamento.rb
+++ b/t/test_parlamento.rb
@@ -32,6 +32,7 @@ describe 'parlamento' do
     it 'should represent correct region' do
       leg_mem = pmems.find { |m| m[:role] == 'member' }
       leg_mem[:area][:name].must_equal 'Lazio'
+      leg_mem[:area][:id].must_equal 'area/lazio'
     end
 
     it 'should be in correct chamber' do


### PR DESCRIPTION
If an `area_id` field (or suitable aliases, parallel to the `area` field) is supplied, use it, otherwise generate one.
