### PR TITLE
v0.11.0 Make terms first-class Events

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,0 +1,54 @@
+0.11.0  2015-09-06
+  - terms are now first class Events, rather than embedded on the
+    legislature organization
+
+0.10.1  2015-08-11
+  - Allow multiple Organizations with the same name, as long as they
+    have different `organization_id`s
+
+0.10.0  2015-08-06
+  - Turn any `identifier__xxx` column into an Identifier
+
+0.9.8  2015-06-25
+  - Accept `area_id` columns
+
+0.9.7  2015-06-18
+  - Default an empty Party name to "Unknown"
+
+0.9.6  2015-06-18
+  - Derive IDs from names, for persistence, rather than generating UUIDs
+
+0.9.5  2015-06-17
+  - Ensure Person records are unique
+
+0.9.3  2015-05-25
+  -  Allow a `source` column
+  -  Allow `party_name` as alias for `party`
+  -  Skip blank `executive` entries
+
+0.9.2  2015-05-24
+  -  Allow `photograph` as alias for `image`
+
+0.9.1  2015-05-07
+  -  Allow `name_en` as an alias for `name`, as a first step towards
+     better handling of multi-lingual data
+
+0.9.0  2015-05-03
+  - Prefix bare personIDs with 'person/'  
+
+0.8.4  2015-05-01
+  - Cope with blank column names
+
+0.8.3  2015-05-01
+  - Warn about duplicated column names
+
+0.8.2  2015-05-01
+  - Add aliases for district, place, mob, cellphone, date_of_death, dod,
+    sex, patronym, patronymic, site
+
+0.8.1  2015-04-23
+  - Accept a `term` 
+
+
+
+

--- a/lib/csv_to_popolo.rb
+++ b/lib/csv_to_popolo.rb
@@ -177,6 +177,7 @@ class Popolo
         persons:       persons,
         organizations: organizations,
         memberships:   memberships,
+        events:        terms,
         warnings:      warnings
       }.select { |_, v| !v.nil? }
     end
@@ -235,7 +236,6 @@ class Popolo
           id: 'legislature',
           name: 'Legislature',
           classification: 'legislature',
-          legislative_periods: terms
         }.select { |_, v| !v.nil? }
       ]
     end

--- a/lib/csv_to_popolo/version.rb
+++ b/lib/csv_to_popolo/version.rb
@@ -1,3 +1,3 @@
 module Popolo_CSV
-  VERSION = '0.10.1'
+  VERSION = '0.11.0'
 end

--- a/t/test_riigikogud.rb
+++ b/t/test_riigikogud.rb
@@ -5,15 +5,13 @@ require 'json'
 describe 'riigikogu' do
   subject { Popolo::CSV.new('t/data/riigikogu-multi.csv') }
 
-  let(:pers) { subject.data[:persons] }
-  let(:orgs) { subject.data[:organizations] }
-  let(:mems) { subject.data[:memberships] }
-  let(:legm) { mems.select { |m| m[:role] == 'member' } }
+  let(:pers)  { subject.data[:persons] }
+  let(:orgs)  { subject.data[:organizations] }
+  let(:mems)  { subject.data[:memberships] }
+  let(:legm)  { mems.select { |m| m[:role] == 'member' } }
+  let(:terms) { subject.data[:events] }
 
   describe 'riigikogu' do
-    let(:riigikogu) { orgs.find { |o| o[:classification] == 'legislature' } }
-    let(:terms) { riigikogu[:legislative_periods] }
-
     it 'should have two terms' do
       terms.count.must_equal 2
     end


### PR DESCRIPTION
Rather than storing the legislative periods on the Organization (as a workaround to Popit not handling them), make them full Events.
