### PR TITLE
v0.12.0 promote constituencies to first class Areas

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,7 @@
+0.12.0  2015-09-06
+  - constituencies are now first class Areas, rather than embedded on
+    the Memberships
+
 0.11.0  2015-09-06
   - terms are now first class Events, rather than embedded on the
     legislature organization

--- a/lib/csv_to_popolo/version.rb
+++ b/lib/csv_to_popolo/version.rb
@@ -1,3 +1,3 @@
 module Popolo_CSV
-  VERSION = '0.11.0'
+  VERSION = '0.12.0'
 end

--- a/t/test_area_ids.rb
+++ b/t/test_area_ids.rb
@@ -6,10 +6,11 @@ require 'json'
 describe 'Bhutan' do
   subject { Popolo::CSV.new('t/data/malaysia.csv') }
 
-  let(:ppl)  { subject.data[:persons] }
-  let(:orgs) { subject.data[:organizations] }
-  let(:mems) { subject.data[:memberships] }
-  let(:legm) { mems.select { |m| m[:role] == 'member' } }
+  let(:ppl)   { subject.data[:persons] }
+  let(:orgs)  { subject.data[:organizations] }
+  let(:areas) { subject.data[:areas] }
+  let(:mems)  { subject.data[:memberships] }
+  let(:legm)  { mems.select { |m| m[:role] == 'member' } }
 
   describe 'Shaharuddin Ismail' do
     it 'should have one legislative membership' do
@@ -18,8 +19,8 @@ describe 'Bhutan' do
 
     it 'should have a source' do
       lm = legm.find { |m| m[:person_id] == 'person/shaharuddin_ismail' }
-      lm[:area][:name].must_equal 'Kangar, Perlis'
-      lm[:area][:id].must_equal 'P002'
+      lm[:area_id].must_equal 'P002'
+      areas.find { |a| a[:id] == lm[:area_id] }[:name].must_equal 'Kangar, Perlis'
     end
   end
 end

--- a/t/test_parlamento.rb
+++ b/t/test_parlamento.rb
@@ -31,8 +31,8 @@ describe 'parlamento' do
 
     it 'should represent correct region' do
       leg_mem = pmems.find { |m| m[:role] == 'member' }
-      leg_mem[:area][:name].must_equal 'Lazio'
-      leg_mem[:area][:id].must_equal 'area/lazio'
+      leg_mem[:area_id].must_equal 'area/lazio'
+      subject.data[:areas].find { |a| a[:id] == leg_mem[:area_id] }[:name].must_equal 'Lazio'
     end
 
     it 'should be in correct chamber' do
@@ -63,7 +63,7 @@ describe 'parlamento' do
 
     it 'should represent correct region' do
       leg_mem = pmems.find { |m| m[:role] == 'member' }
-      leg_mem[:area][:name].must_equal 'Sicilia 2'
+      subject.data[:areas].find { |a| a[:id] == leg_mem[:area_id] }[:name].must_equal 'Sicilia 2'
     end
 
     it 'should be in correct chamber' do

--- a/t/test_riigikogu.rb
+++ b/t/test_riigikogu.rb
@@ -32,7 +32,7 @@ describe 'riigikogu' do
 
     it 'should represent correct region' do
       mem = mems.find { |m| m[:role] == 'member' }
-      mem[:area][:name].must_include 'Tallinna Kesklinna'
+      mem[:area_id].must_include 'kesklinna'
     end
 
     it 'should have no start and end dates' do

--- a/t/test_wales.rb
+++ b/t/test_wales.rb
@@ -69,7 +69,7 @@ describe 'welsh assembly' do
     end
 
     it 'should have Assembly membership' do
-      fmem.find { |m| m[:role] == 'member' }[:area][:name].must_equal 'Bridgend'
+      fmem.find { |m| m[:role] == 'member' }[:area_id].must_equal 'area/bridgend'
     end
 
     it 'should have Executive membership' do


### PR DESCRIPTION
Constituencies are now first-class Areas, rather than embedded on the Memberships
