### PR TITLE
0.14 accept wikipedia__{code} links

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,6 @@
+0.14.0  2015-10-23
+  - transform wikipedia__{code} columns into Person:Links 
+
 0.13.0  2015-09-24
   - accept foreign language names as 'name__XX'
 

--- a/lib/csv_to_popolo.rb
+++ b/lib/csv_to_popolo.rb
@@ -335,17 +335,26 @@ class Popolo
     end
 
     def links
-      links = MODEL.select { |_, v| v[:type] == 'link' }
+      require 'pry'
+      links = (MODEL.select { |_, v| v[:type] == 'link' }
               .map    { |k, _| k }
               .select { |type| given? type }
-              .map    { |type| { url: @r[type], note: type.to_s } }
-              .compact
+              .map    { |type| { url: @r[type], note: type.to_s } } + wikipedia_links).compact
       links.count.zero? ? nil : links
+    end
+
+    def wikipedia_links
+      @r.keys.find_all { |k| k.to_s.start_with? 'wikipedia__' }.map do |k|
+        _, lang = k.to_s.split(/__/, 2)
+        {
+          url: 'https://%s.wikipedia.org/wiki/%s' % [lang, @r.delete(k).tr(' ','_')],
+          identifier: "Wikipedia (#{lang})",
+        }
+      end
     end
 
     # Can't know up front what these might be; take anything in the form
     #   identifier__xxx
-
     def identifiers
       @r.keys.find_all { |k| k.to_s.start_with? 'identifier__' }.map do |k|
         {

--- a/lib/csv_to_popolo/version.rb
+++ b/lib/csv_to_popolo/version.rb
@@ -1,3 +1,3 @@
 module Popolo_CSV
-  VERSION = '0.13.0'
+  VERSION = '0.14.0'
 end

--- a/t/test_uk_hoc.rb
+++ b/t/test_uk_hoc.rb
@@ -19,6 +19,11 @@ describe 'UK' do
       names['uk'].must_equal 'Іан Данкан Сміт' 
     end
 
+    it 'should also have several Wikipedia links' do
+      ids[:links].find { |l| l[:identifier] == 'Wikipedia (en)' }[:url].must_equal 'https://en.wikipedia.org/wiki/Iain_Duncan_Smith'
+      ids[:links].find { |l| l[:identifier] == 'Wikipedia (zh)' }[:url].must_equal 'https://zh.wikipedia.org/wiki/施志安'
+    end
+
     it 'should set code back correctly' do
       # comes in as 'name__de_ch'
       names['de-ch'].must_equal 'Iain Duncan Smith'


### PR DESCRIPTION
Columns such as `wikipedia__en` are turned into relevant `links` on the Person
