### PR TITLE
0.14.1 Bugfix: links should have 'note's

### DIFF
--- a/lib/csv_to_popolo.rb
+++ b/lib/csv_to_popolo.rb
@@ -348,7 +348,7 @@ class Popolo
         _, lang = k.to_s.split(/__/, 2)
         {
           url: 'https://%s.wikipedia.org/wiki/%s' % [lang, @r.delete(k).tr(' ','_')],
-          identifier: "Wikipedia (#{lang})",
+          note: "Wikipedia (#{lang})",
         }
       end
     end

--- a/lib/csv_to_popolo/version.rb
+++ b/lib/csv_to_popolo/version.rb
@@ -1,3 +1,3 @@
 module Popolo_CSV
-  VERSION = '0.14.0'
+  VERSION = '0.14.1'
 end

--- a/t/test_uk_hoc.rb
+++ b/t/test_uk_hoc.rb
@@ -20,8 +20,8 @@ describe 'UK' do
     end
 
     it 'should also have several Wikipedia links' do
-      ids[:links].find { |l| l[:identifier] == 'Wikipedia (en)' }[:url].must_equal 'https://en.wikipedia.org/wiki/Iain_Duncan_Smith'
-      ids[:links].find { |l| l[:identifier] == 'Wikipedia (zh)' }[:url].must_equal 'https://zh.wikipedia.org/wiki/施志安'
+      ids[:links].find { |l| l[:note] == 'Wikipedia (en)' }[:url].must_equal 'https://en.wikipedia.org/wiki/Iain_Duncan_Smith'
+      ids[:links].find { |l| l[:note] == 'Wikipedia (zh)' }[:url].must_equal 'https://zh.wikipedia.org/wiki/施志安'
     end
 
     it 'should set code back correctly' do


### PR DESCRIPTION
A link should have a 'note', not an 'identifier'
