### PR TITLE
0.15 Don't add "person/" prefixes

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,6 @@
+0.15.0  2015-11-03
+  - don't prepend person IDs with "person/"
+
 0.14.0  2015-10-23
   - transform wikipedia__{code} columns into Person:Links 
 

--- a/lib/csv_to_popolo.rb
+++ b/lib/csv_to_popolo.rb
@@ -165,8 +165,7 @@ class Popolo
     def initialize(file)
       @raw_csv = ::CSV.read(file, OPTS)
       @csv = @raw_csv.map do |r|
-        r[:id] ||= "person/#{_idify(r[:name] || raise('creating ID without a name'))}"
-        r[:id].prepend 'person/' unless r[:id].start_with? 'person/'
+        r[:id] ||= "#{_idify(r[:name] || raise('creating ID without a name'))}"
         r[:group] = 'unknown' if r[:group].to_s.empty?
         r.to_hash.select { |_, v| !v.nil? }
       end

--- a/lib/csv_to_popolo/version.rb
+++ b/lib/csv_to_popolo/version.rb
@@ -1,3 +1,3 @@
 module Popolo_CSV
-  VERSION = '0.14.1'
+  VERSION = '0.15.0'
 end

--- a/t/test_area_ids.rb
+++ b/t/test_area_ids.rb
@@ -14,11 +14,11 @@ describe 'Bhutan' do
 
   describe 'Shaharuddin Ismail' do
     it 'should have one legislative membership' do
-      legm.count { |m| m[:person_id] == 'person/shaharuddin_ismail' }.must_equal 1
+      legm.count { |m| m[:person_id] == 'shaharuddin_ismail' }.must_equal 1
     end
 
     it 'should have a source' do
-      lm = legm.find { |m| m[:person_id] == 'person/shaharuddin_ismail' }
+      lm = legm.find { |m| m[:person_id] == 'shaharuddin_ismail' }
       lm[:area_id].must_equal 'P002'
       area = areas.find { |a| a[:id] == lm[:area_id] }
       area[:name].must_equal 'Kangar, Perlis'

--- a/t/test_bhutan.rb
+++ b/t/test_bhutan.rb
@@ -11,8 +11,8 @@ describe 'Bhutan' do
   let(:mems) { subject.data[:memberships] }
   let(:legm) { mems.select { |m| m[:role] == 'member' } }
 
-  let(:pm) { ppl.find { |i| i[:id] == 'person/1'  } }
-  let(:mp) { ppl.find { |i| i[:id] == 'person/20' } }
+  let(:pm) { ppl.find { |i| i[:id] == '1'  } }
+  let(:mp) { ppl.find { |i| i[:id] == '20' } }
 
   describe 'The Prime Minster' do
     it 'should have two memberships' do

--- a/t/test_eduskunta.rb
+++ b/t/test_eduskunta.rb
@@ -10,8 +10,8 @@ describe 'eduskunta' do
   let(:orgs) { subject.data[:organizations] }
   let(:mems) { subject.data[:memberships] }
 
-  let(:ahde) { pers.find     { |p| p[:id] == 'person/104' } }
-  let(:amms) { mems.select { |m| m[:person_id] == 'person/104' } }
+  let(:ahde) { pers.find     { |p| p[:id] == '104' } }
+  let(:amms) { mems.select { |m| m[:person_id] == '104' } }
   let(:kesk) { orgs.find     { |o| o[:name] == 'Finnish Centre Party' } }
 
   it 'should set party name correctly' do

--- a/t/test_eduskunta_mini.rb
+++ b/t/test_eduskunta_mini.rb
@@ -9,15 +9,15 @@ describe 'eduskunta' do
   let(:orgs) { subject.data[:organizations] }
   let(:mems) { subject.data[:memberships] }
 
-  let(:aho)  { pers.find { |i| i[:id] == 'person/104' } }
-  let(:amms) { mems.select { |i| i[:person_id] == 'person/104' } }
+  let(:aho)  { pers.find { |i| i[:id] == '104' } }
+  let(:amms) { mems.select { |i| i[:person_id] == '104' } }
 
   it 'should have the correct name' do
     aho[:name].must_equal 'Aho Esko'
   end
 
   it 'should have the correct id' do
-    aho[:id].must_equal 'person/104'
+    aho[:id].must_equal '104'
   end
 
   it 'should have the correct family name' do

--- a/t/test_monaco.rb
+++ b/t/test_monaco.rb
@@ -11,17 +11,17 @@ describe 'monaco' do
   let(:mems) { subject.data[:memberships] }
 
   it 'should have have one person' do
-    pc = pers.find_all { |p| p[:id] == 'person/Philippe-CLERISSI' }
+    pc = pers.find_all { |p| p[:id] == 'Philippe-CLERISSI' }
     pc.size.must_equal 1
   end
 
   it 'should have have two memberships' do
-    pc = mems.find_all { |p| p[:person_id] == 'person/Philippe-CLERISSI' }
+    pc = mems.find_all { |p| p[:person_id] == 'Philippe-CLERISSI' }
     pc.size.must_equal 2
   end
 
   it 'should have one membership for an unknown party' do
-    pc = mems.find_all { |p| p[:person_id] == 'person/Philippe-CLERISSI' }
+    pc = mems.find_all { |p| p[:person_id] == 'Philippe-CLERISSI' }
     pc.find_all { |m| m[:on_behalf_of_id] == 'party/unknown' }.size.must_equal 1
   end
 

--- a/t/test_parlamento.rb
+++ b/t/test_parlamento.rb
@@ -11,7 +11,7 @@ describe 'parlamento' do
   let(:mems) { subject.data[:memberships] }
 
   describe 'Grasso' do
-    let(:member) { ppl.find { |i| i[:id] == 'person/687024' } }
+    let(:member) { ppl.find { |i| i[:id] == '687024' } }
     let(:pmems)  { mems.select { |m| m[:person_id] == member[:id] } }
 
     it 'should have the correct name' do
@@ -43,7 +43,7 @@ describe 'parlamento' do
   end
 
   describe 'Boldrini' do
-    let(:member) { ppl.find { |i| i[:id] == 'person/686427' } }
+    let(:member) { ppl.find { |i| i[:id] == '686427' } }
     let(:pmems)  { mems.select { |m| m[:person_id] == member[:id] } }
 
     it 'should have the correct name' do

--- a/t/test_riigikogu.rb
+++ b/t/test_riigikogu.rb
@@ -17,7 +17,7 @@ describe 'riigikogu' do
     end
 
     it 'should have the correct id' do
-      arto[:id].must_equal 'person/fe748f4d-3f50-4af8-8069-92a460978d2b'
+      arto[:id].must_equal 'fe748f4d-3f50-4af8-8069-92a460978d2b'
     end
 
     it 'should have correct faction info' do

--- a/t/test_riigikogud.rb
+++ b/t/test_riigikogud.rb
@@ -30,7 +30,7 @@ describe 'riigikogu' do
     let(:amms) { legm.select { |m| m[:person_id] == arto[:id] } }
 
     it 'should have the correct id' do
-      arto[:id].must_equal 'person/fe748f4d-3f50-4af8-8069-92a460978d2b'
+      arto[:id].must_equal 'fe748f4d-3f50-4af8-8069-92a460978d2b'
     end
 
     it 'should have two legislative memberships' do

--- a/t/test_tcamp.rb
+++ b/t/test_tcamp.rb
@@ -98,7 +98,7 @@ describe 'tcamp' do
     end
 
     it 'should generate ids' do
-      ids.first.must_equal 'person/tom_steinberg'
+      ids.first.must_equal 'tom_steinberg'
     end
   end
 

--- a/t/test_uk_hoc.rb
+++ b/t/test_uk_hoc.rb
@@ -8,7 +8,7 @@ describe 'UK' do
 
   describe 'Iain Duncan Smith' do
 
-    let(:ids)   { subject.data[:persons].find { |i| i[:id] == 'person/Q302486' } }
+    let(:ids)   { subject.data[:persons].find { |i| i[:id] == 'Q302486' } }
     let(:names) { Hash[ids[:other_names].select { |n| n[:note] == 'multilingual' }.map { |n| [n[:lang], n[:name]] }] }
 
     it 'should have a default name' do

--- a/t/test_wales.rb
+++ b/t/test_wales.rb
@@ -8,7 +8,7 @@ describe 'welsh assembly' do
   let(:mems) { subject.data[:memberships] }
 
   describe 'Asghar' do
-    let(:asghar) { pers.find { |i| i[:id] == 'person/130' } }
+    let(:asghar) { pers.find { |i| i[:id] == '130' } }
 
     it 'should have the correct name' do
       asghar[:name].must_equal 'Mohammad Asghar'
@@ -61,7 +61,7 @@ describe 'welsh assembly' do
 
   describe 'First Minister' do
     let(:executive) { orgs.find { |o| o[:id] == 'executive' } }
-    let(:fmin) { pers.find   { |p| p[:id] == 'person/102' } }
+    let(:fmin) { pers.find   { |p| p[:id] == '102' } }
     let(:fmem) { mems.select { |m| m[:person_id] == fmin[:id] } }
 
     it 'should have two memberships' do


### PR DESCRIPTION
When generating person IDs, don't add a "person/" prefix.
