### PR TITLE
v0.18.0 standardise Twitter handles

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,7 @@
+0.18.0  2016-01-11
+  - Transform a 'twitter' column (in multiple possible formats) into a
+    standardised entry in both contact_details and links
+
 0.17.1  2016-01-07
   - Skip alternate names that are blank
 

--- a/csv_to_popolo.gemspec
+++ b/csv_to_popolo.gemspec
@@ -25,4 +25,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry'
 
   spec.add_dependency 'json'
+  spec.add_dependency 'twitter_username_extractor'
 end

--- a/lib/csv_to_popolo.rb
+++ b/lib/csv_to_popolo.rb
@@ -1,5 +1,6 @@
 require 'csv_to_popolo/version'
 require 'csv'
+require 'twitter_username_extractor'
 
 class Popolo
   MODEL = {
@@ -338,6 +339,9 @@ class Popolo
     end
 
     def contact_details
+      # Standardise Twitter handles
+      @r[:twitter] = TwitterUsernameExtractor.extract(@r[:twitter]) if given? :twitter
+
       contacts = MODEL.select { |_, v| v[:type] == 'contact' }
                  .map    { |k, _| k }
                  .select { |type| given? type }
@@ -347,7 +351,6 @@ class Popolo
     end
 
     def links
-      require 'pry'
       links = (MODEL.select { |_, v| v[:type] == 'link' }
               .map    { |k, _| k }
               .select { |type| given? type }

--- a/lib/csv_to_popolo.rb
+++ b/lib/csv_to_popolo.rb
@@ -354,7 +354,7 @@ class Popolo
       links = (MODEL.select { |_, v| v[:type] == 'link' }
               .map    { |k, _| k }
               .select { |type| given? type }
-              .map    { |type| { url: @r[type], note: type.to_s } } + wikipedia_links).compact
+              .map    { |type| { url: @r[type], note: type.to_s } } + wikipedia_links + twitter_link).compact
       links.count.zero? ? nil : links
     end
 
@@ -366,6 +366,14 @@ class Popolo
           note: "Wikipedia (#{lang})",
         }
       end
+    end
+
+    def twitter_link
+      return [] unless given? :twitter
+      [{
+        url: 'https://twitter.com/' + @r[:twitter],
+        note: 'twitter'
+      }]
     end
 
     # Can't know up front what these might be; take anything in the form

--- a/lib/csv_to_popolo/version.rb
+++ b/lib/csv_to_popolo/version.rb
@@ -1,3 +1,3 @@
 module Popolo_CSV
-  VERSION = '0.17.1'
+  VERSION = '0.18.0'
 end

--- a/t/data/tcamp.csv
+++ b/t/data/tcamp.csv
@@ -1,5 +1,5 @@
 org,name,first_name,last_name,twitter,mobile,fax,wikipedia,identifier__tcampid,identifier__EFP
-mySociety,Tom Steinberg,Tom,Steinberg,steiny,,,http://en.wikipedia.org/wiki/Tom_Steinberg,14,a40
+mySociety,Tom Steinberg,Tom,Steinberg,@steiny,,,http://en.wikipedia.org/wiki/Tom_Steinberg,14,a40
 mySociety,Tom Steinberg,,,,tomsphone,,,,a50
-Sunlight Foundation,Ellen Miller,Ellen,Miller,EllnMllr,ellensphone,ellensfax,http://en.wikipedia.org/wiki/Ellen_S._Miller,10,c49
+Sunlight Foundation,Ellen Miller,Ellen,Miller,http://www.twitter.com/#!/EllnMllr,ellensphone,ellensfax,http://en.wikipedia.org/wiki/Ellen_S._Miller,10,c49
 ,Orgless,,,,,,,

--- a/t/test_tcamp.rb
+++ b/t/test_tcamp.rb
@@ -41,6 +41,10 @@ describe 'tcamp' do
       steiny[:links].find { |l| l[:note] == 'wikipedia' }[:url].must_equal 'http://en.wikipedia.org/wiki/Tom_Steinberg'
     end
 
+    it 'should have a twitter link' do
+      steiny[:links].find { |l| l[:note] == 'twitter' }[:url].must_equal 'https://twitter.com/steiny'
+    end
+
     it 'should have identifiers' do
       steiny[:identifiers].find { |l| l[:scheme] == 'tcampid' }[:identifier].must_equal '14'
       steiny[:identifiers].select { |l| l[:scheme] == 'efp' and l[:identifier] == 'a40' }.count.must_equal 1
@@ -54,6 +58,10 @@ describe 'tcamp' do
 
     it 'should standardise the twitter handle' do
       ellen[:contact_details].find { |c| c[:type] == 'twitter' }[:value].must_equal 'EllnMllr'
+    end
+
+    it 'should have a twitter link' do
+      ellen[:links].find { |l| l[:note] == 'twitter' }[:url].must_equal 'https://twitter.com/EllnMllr'
     end
 
     it 'should have a phone number' do
@@ -80,6 +88,10 @@ describe 'tcamp' do
 
     it "shouldn't have a twitter handle" do
       orgless[:contact_details].must_be_nil
+    end
+
+    it "shouldn't have a twitter link" do
+      orgless[:links].must_be_nil
     end
 
     it 'should only have one legislative membership' do

--- a/t/test_tcamp.rb
+++ b/t/test_tcamp.rb
@@ -25,7 +25,7 @@ describe 'tcamp' do
       party[:name].must_equal 'mySociety'
     end
 
-    it 'should have a twitter handle' do
+    it 'should standardise the twitter handle' do
       steiny[:contact_details].find { |c| c[:type] == 'twitter' }[:value].must_equal 'steiny'
     end
 
@@ -52,7 +52,7 @@ describe 'tcamp' do
   describe 'ellen' do
     let(:ellen)  { subject.data[:persons][1] }
 
-    it 'should have a twitter handle' do
+    it 'should standardise the twitter handle' do
       ellen[:contact_details].find { |c| c[:type] == 'twitter' }[:value].must_equal 'EllnMllr'
     end
 


### PR DESCRIPTION
Convert all twitter handles to a standardised format using
TwitterUsernameExtractor, and expand them into both `contact_details`
and `links`
