### PR TITLE
Add basic support for having multiple values within a cell

### DIFF
--- a/lib/csv_to_popolo.rb
+++ b/lib/csv_to_popolo.rb
@@ -53,7 +53,8 @@ class Popolo
       aliases: %w(post)
     },
     facebook: {
-      type: 'link'
+      type: 'link',
+      multivalue_separator: ';'
     },
     family_name: {
       aliases: %w(last_name surname lastname),
@@ -356,6 +357,8 @@ class Popolo
       values.map do |v|
         if key == :twitter
           TwitterUsernameExtractor.extract(v) rescue nil
+        elsif key == :facebook
+          "https://facebook.com/#{FacebookUsernameExtractor.extract(v)}" rescue nil
         else
           v
         end
@@ -380,13 +383,14 @@ class Popolo
     end
 
     def links
-      # Standardise Facebook addresses
-      if given? :facebook
-        @r[:facebook] = "https://facebook.com/#{FacebookUsernameExtractor.extract(@r[:facebook])}" rescue nil
+      links = []
+      keys_with_values_for_type('link').each do |key|
+        cell_values(key).each do |value|
+          links.push(note: key.to_s, url: value)
+        end
       end
-
-      links = (keys_with_values_for_type('link')
-              .map    { |type| { url: @r[type], note: type.to_s } } + wikipedia_links + twitter_links).compact
+      links += wikipedia_links + twitter_links
+      links.compact!
       links.count.zero? ? nil : links
     end
 

--- a/lib/csv_to_popolo.rb
+++ b/lib/csv_to_popolo.rb
@@ -27,7 +27,8 @@ class Popolo
     },
     blog: {
       aliases: %w(weblog),
-      type: 'link'
+      type: 'link',
+      multivalue_separator: ';'
     },
     cell: {
       aliases: %w(mob mobile cellphone),
@@ -66,7 +67,8 @@ class Popolo
       multivalue_separator: ';'
     },
     flickr: {
-      type: 'link'
+      type: 'link',
+      multivalue_separator: ';'
     },
     gender: {
       aliases: %w(sex),
@@ -101,10 +103,12 @@ class Popolo
       type: 'asis'
     },
     instagram: {
-      type: 'link'
+      type: 'link',
+      multivalue_separator: ';'
     },
     linkedin: {
-      type: 'link'
+      type: 'link',
+      multivalue_separator: ';'
     },
     name: {
       type: 'asis',
@@ -143,13 +147,16 @@ class Popolo
     },
     website: {
       type: 'link',
-      aliases: %w(homepage href url site)
+      aliases: %w(homepage href url site),
+      multivalue_separator: ';'
     },
     wikipedia: {
-      type: 'link'
+      type: 'link',
+      multivalue_separator: ';'
     },
     youtube: {
-      type: 'link'
+      type: 'link',
+      multivalue_separator: ';'
     },
 
     other_name: {}

--- a/lib/csv_to_popolo.rb
+++ b/lib/csv_to_popolo.rb
@@ -100,7 +100,9 @@ class Popolo
     },
     image: {
       aliases: %w(img picture photo photograph portrait),
-      type: 'asis'
+      type: 'image',
+      multivalue_separator: ';',
+      take_first: 'asis'
     },
     instagram: {
       type: 'link',
@@ -471,7 +473,9 @@ class Popolo
 
       popolo[:contact_details] = contact_details
       popolo[:links] = links
-      popolo[:images] = [{ url: @r[:image] }] unless @r[:image].to_s.empty?
+      if given? :image
+        popolo[:images] = cell_values(:image).map { |i| {url: i} }
+      end
       popolo[:sources] = [{ url: @r[:source] }] if given? :source
 
       popolo.reject { |_, v| v.nil? || v.empty? }

--- a/lib/csv_to_popolo.rb
+++ b/lib/csv_to_popolo.rb
@@ -8,7 +8,7 @@ class Popolo
     additional_name: {
       type: 'asis'
     },
-    alternate_names: { 
+    alternate_names: {
       aliases: %w(other_names alternative_names)
     },
     area: {
@@ -218,7 +218,7 @@ class Popolo
 
     def areas
       @_areas ||= @csv.select { |r| (r.key?(:area) && !r[:area].to_s.empty?) || (r.key?(:area_id) && !r[:area_id].to_s.empty?) }.map { |r|
-        { 
+        {
           id: r[:area_id].to_s.empty? ? "area/#{_idify(r[:area])}" : r[:area_id],
           name: r[:area] || 'unknown',
           type: 'constituency',
@@ -304,8 +304,8 @@ class Popolo
     end
 
     def warnings
-      handled = @raw_csv.headers.partition { |h| 
-        MODEL.key?(h) || h.to_s.start_with?('identifier__') || h.to_s.start_with?('name__') 
+      handled = @raw_csv.headers.partition { |h|
+        MODEL.key?(h) || h.to_s.start_with?('identifier__') || h.to_s.start_with?('name__')
         # || h.to_s.start_with?('wikipedia__')
       }
 

--- a/lib/csv_to_popolo.rb
+++ b/lib/csv_to_popolo.rb
@@ -42,7 +42,9 @@ class Popolo
       type: 'asis'
     },
     email: {
-      type: 'asis'
+      type: 'contact',
+      multivalue_separator: ';',
+      take_first: 'asis'
     },
     end_date: {
       aliases: %w(end ended until to)
@@ -438,6 +440,11 @@ class Popolo
       as_is = MODEL.select { |_, v| v[:type] == 'asis' }.map { |k, _| k }
       as_is.each do |sym|
         popolo[sym] = @r[sym] if given? sym
+      end
+
+      take_first_as_is = MODEL.select { |_, v| v[:take_first] == 'asis' }.map{ |k, _| k }
+      take_first_as_is.each do |sym|
+        popolo[sym] = cell_values(sym)[0] if given? sym
       end
 
       popolo[:identifiers] = identifiers

--- a/lib/csv_to_popolo.rb
+++ b/lib/csv_to_popolo.rb
@@ -361,7 +361,7 @@ class Popolo
         values = [@r[key]]
       end
       # Normalize some values depending on the column:
-      values.map do |v|
+      values.map(&:strip).map do |v|
         if key == :twitter
           TwitterUsernameExtractor.extract(v) rescue nil
         elsif key == :facebook

--- a/lib/csv_to_popolo.rb
+++ b/lib/csv_to_popolo.rb
@@ -339,15 +339,19 @@ class Popolo
       @r.key?(key) && !@r[key].nil? && !@r[key].empty?
     end
 
+    def keys_with_values_for_type(type)
+      MODEL.select { |_, v| v[:type] == type }
+           .map    { |k, _| k }
+           .select { |key| given? key }
+    end
+
     def contact_details
       # Standardise Twitter handles
       if given? :twitter
         @r[:twitter] = TwitterUsernameExtractor.extract(@r[:twitter]) rescue nil
       end
 
-      contacts = MODEL.select { |_, v| v[:type] == 'contact' }
-                 .map    { |k, _| k }
-                 .select { |type| given? type }
+      contacts = keys_with_values_for_type('contact')
                  .map    { |type| { type: type.to_s, value: @r[type] } }
                  .compact
       contacts.count.zero? ? nil : contacts
@@ -359,9 +363,7 @@ class Popolo
         @r[:facebook] = "https://facebook.com/#{FacebookUsernameExtractor.extract(@r[:facebook])}" rescue nil
       end
 
-      links = (MODEL.select { |_, v| v[:type] == 'link' }
-              .map    { |k, _| k }
-              .select { |type| given? type }
+      links = (keys_with_values_for_type('link')
               .map    { |type| { url: @r[type], note: type.to_s } } + wikipedia_links + twitter_link).compact
       links.count.zero? ? nil : links
     end

--- a/lib/csv_to_popolo.rb
+++ b/lib/csv_to_popolo.rb
@@ -31,7 +31,8 @@ class Popolo
     },
     cell: {
       aliases: %w(mob mobile cellphone),
-      type: 'contact'
+      type: 'contact',
+      multivalue_separator: ';'
     },
     chamber: {
       aliases: %w(house)
@@ -58,7 +59,8 @@ class Popolo
     },
     fax: {
       aliases: %w(facsimile),
-      type: 'contact'
+      type: 'contact',
+      multivalue_separator: ';'
     },
     flickr: {
       type: 'link'
@@ -114,7 +116,8 @@ class Popolo
     },
     phone: {
       aliases: %w(tel telephone),
-      type: 'contact'
+      type: 'contact',
+      multivalue_separator: ';'
     },
     sort_name: {
       type: 'asis'
@@ -339,6 +342,15 @@ class Popolo
       @r.key?(key) && !@r[key].nil? && !@r[key].empty?
     end
 
+    def cell_values(key)
+      separator = MODEL[key][:multivalue_separator]
+      if separator
+        @r[key].split(separator)
+      else
+        [@r[key]]
+      end
+    end
+
     def keys_with_values_for_type(type)
       MODEL.select { |_, v| v[:type] == type }
            .map    { |k, _| k }
@@ -351,9 +363,13 @@ class Popolo
         @r[:twitter] = TwitterUsernameExtractor.extract(@r[:twitter]) rescue nil
       end
 
-      contacts = keys_with_values_for_type('contact')
-                 .map    { |type| { type: type.to_s, value: @r[type] } }
-                 .compact
+      contacts = []
+      keys_with_values_for_type('contact').each do |key|
+        cell_values(key).each do |value|
+          contacts.push(type: key.to_s, value: value)
+        end
+      end
+      contacts.compact!
       contacts.count.zero? ? nil : contacts
     end
 

--- a/t/data/multiple_contacts_in_cells.csv
+++ b/t/data/multiple_contacts_in_cells.csv
@@ -1,0 +1,3 @@
+name,email,cell,mobile
+John Doe,foo@example.org,555;666,777;888
+David Cameron,camerond@parliament.uk;info@davidcameron.com,,

--- a/t/data/multiple_contacts_in_cells.csv
+++ b/t/data/multiple_contacts_in_cells.csv
@@ -1,3 +1,0 @@
-name,email,cell,mobile,twitter
-John Doe,foo@example.org,555;666,777;888,
-David Cameron,camerond@parliament.uk;info@davidcameron.com,,,https://twitter.com/David_Cameron;@Number10gov

--- a/t/data/multiple_contacts_in_cells.csv
+++ b/t/data/multiple_contacts_in_cells.csv
@@ -1,3 +1,3 @@
-name,email,cell,mobile
-John Doe,foo@example.org,555;666,777;888
-David Cameron,camerond@parliament.uk;info@davidcameron.com,,
+name,email,cell,mobile,twitter
+John Doe,foo@example.org,555;666,777;888,
+David Cameron,camerond@parliament.uk;info@davidcameron.com,,,https://twitter.com/David_Cameron;@Number10gov

--- a/t/data/multiple_values_in_cells.csv
+++ b/t/data/multiple_values_in_cells.csv
@@ -1,0 +1,3 @@
+name,email,cell,mobile,twitter,facebook,homepage
+John Doe,foo@example.org,555;666,777;888,,,
+David Cameron,camerond@parliament.uk;info@davidcameron.com,,,https://twitter.com/David_Cameron;@Number10gov,https://www.facebook.com/DavidCameronOfficial/;https://en-gb.facebook.com/SomeOtherDavidCameron/;UnqualifiedDavidCameron,http://cameron.example.org;https://www.conservatives.com/OurTeam/David_Cameron

--- a/t/data/multiple_values_in_cells.csv
+++ b/t/data/multiple_values_in_cells.csv
@@ -1,3 +1,3 @@
-name,email,cell,mobile,twitter,facebook,homepage
-John Doe,foo@example.org,555;666,777 ; 888 ,,,
-David Cameron,camerond@parliament.uk;info@davidcameron.com,,,https://twitter.com/David_Cameron;@Number10gov,https://www.facebook.com/DavidCameronOfficial/;https://en-gb.facebook.com/SomeOtherDavidCameron/ ; UnqualifiedDavidCameron,http://cameron.example.org;https://www.conservatives.com/OurTeam/David_Cameron
+name,email,cell,mobile,twitter,facebook,homepage,image
+John Doe,foo@example.org,555;666,777 ; 888 ,,,,http://example.org/a.jpg;http://example.org/b.png
+David Cameron,camerond@parliament.uk;info@davidcameron.com,,,https://twitter.com/David_Cameron;@Number10gov,https://www.facebook.com/DavidCameronOfficial/;https://en-gb.facebook.com/SomeOtherDavidCameron/ ; UnqualifiedDavidCameron,http://cameron.example.org;https://www.conservatives.com/OurTeam/David_Cameron,

--- a/t/data/multiple_values_in_cells.csv
+++ b/t/data/multiple_values_in_cells.csv
@@ -1,3 +1,3 @@
 name,email,cell,mobile,twitter,facebook,homepage
-John Doe,foo@example.org,555;666,777;888,,,
-David Cameron,camerond@parliament.uk;info@davidcameron.com,,,https://twitter.com/David_Cameron;@Number10gov,https://www.facebook.com/DavidCameronOfficial/;https://en-gb.facebook.com/SomeOtherDavidCameron/;UnqualifiedDavidCameron,http://cameron.example.org;https://www.conservatives.com/OurTeam/David_Cameron
+John Doe,foo@example.org,555;666,777 ; 888 ,,,
+David Cameron,camerond@parliament.uk;info@davidcameron.com,,,https://twitter.com/David_Cameron;@Number10gov,https://www.facebook.com/DavidCameronOfficial/;https://en-gb.facebook.com/SomeOtherDavidCameron/ ; UnqualifiedDavidCameron,http://cameron.example.org;https://www.conservatives.com/OurTeam/David_Cameron

--- a/t/test_multivalue_separator.rb
+++ b/t/test_multivalue_separator.rb
@@ -44,4 +44,11 @@ describe 'multivalue_separator' do
     facebook_links[2][:url].must_equal 'https://facebook.com/UnqualifiedDavidCameron'
   end
 
+  it 'should include homepage links for David Cameron' do
+    website_links = cameron[:links].select { |l| l[:note] == 'website' }
+    website_links.count.must_equal 2
+    website_links[0][:url].must_equal 'http://cameron.example.org'
+    website_links[1][:url].must_equal 'https://www.conservatives.com/OurTeam/David_Cameron'
+  end
+
 end

--- a/t/test_multivalue_separator.rb
+++ b/t/test_multivalue_separator.rb
@@ -17,11 +17,24 @@ describe 'multivalue_separator' do
 
   it 'should output two email addresses for David Cameron and set the top-level email field' do
     cameron[:email].must_equal 'camerond@parliament.uk'
-    cameron[:contact_details].count.must_equal 2
-    cameron[:contact_details][0][:type].must_equal 'email'
-    cameron[:contact_details][0][:value].must_equal 'camerond@parliament.uk'
-    cameron[:contact_details][1][:type].must_equal 'email'
-    cameron[:contact_details][1][:value].must_equal 'info@davidcameron.com'
+    email_contacts = cameron[:contact_details].select { |c| c[:type] == 'email' }
+    email_contacts.count.must_equal 2
+    email_contacts[0][:value].must_equal 'camerond@parliament.uk'
+    email_contacts[1][:value].must_equal 'info@davidcameron.com'
+  end
+
+  it 'should include multiple Twitter usernames in both contact_details and links' do
+    # Check the links first...
+    cameron[:links].count.must_equal 2
+    cameron[:links][0][:url].must_equal 'https://twitter.com/David_Cameron'
+    cameron[:links][0][:note].must_equal 'twitter'
+    cameron[:links][1][:url].must_equal 'https://twitter.com/Number10gov'
+    cameron[:links][1][:note].must_equal 'twitter'
+    # Then the contact_details:
+    twitter_contacts = cameron[:contact_details].select { |c| c[:type] == 'twitter' }
+    twitter_contacts.count.must_equal 2
+    twitter_contacts[0][:value].must_equal 'David_Cameron'
+    twitter_contacts[1][:value].must_equal 'Number10gov'
   end
 
 end

--- a/t/test_multivalue_separator.rb
+++ b/t/test_multivalue_separator.rb
@@ -1,0 +1,17 @@
+require 'csv_to_popolo'
+require 'minitest/autorun'
+
+describe 'multivalue_separator' do
+  subject { Popolo::CSV.new('t/data/multiple_contacts_in_cells.csv') }
+
+  let(:pers) { subject.data[:persons] }
+  let(:doe) { pers.find { |p| p[:name] == 'John Doe' } }
+
+  it 'should find both mobile numbers for John Doe' do
+    doe[:contact_details].count.must_equal 3
+    cell_contacts = doe[:contact_details].select { |c| c[:type] == 'cell' }
+    cell_contacts[0][:value].must_equal '777'
+    cell_contacts[1][:value].must_equal '888'
+  end
+
+end

--- a/t/test_multivalue_separator.rb
+++ b/t/test_multivalue_separator.rb
@@ -5,6 +5,7 @@ describe 'multivalue_separator' do
   subject { Popolo::CSV.new('t/data/multiple_contacts_in_cells.csv') }
 
   let(:pers) { subject.data[:persons] }
+  let(:cameron) { pers.find { |p| p[:name] == 'David Cameron' } }
   let(:doe) { pers.find { |p| p[:name] == 'John Doe' } }
 
   it 'should find both mobile numbers for John Doe' do
@@ -12,6 +13,15 @@ describe 'multivalue_separator' do
     cell_contacts = doe[:contact_details].select { |c| c[:type] == 'cell' }
     cell_contacts[0][:value].must_equal '777'
     cell_contacts[1][:value].must_equal '888'
+  end
+
+  it 'should output two email addresses for David Cameron and set the top-level email field' do
+    cameron[:email].must_equal 'camerond@parliament.uk'
+    cameron[:contact_details].count.must_equal 2
+    cameron[:contact_details][0][:type].must_equal 'email'
+    cameron[:contact_details][0][:value].must_equal 'camerond@parliament.uk'
+    cameron[:contact_details][1][:type].must_equal 'email'
+    cameron[:contact_details][1][:value].must_equal 'info@davidcameron.com'
   end
 
 end

--- a/t/test_multivalue_separator.rb
+++ b/t/test_multivalue_separator.rb
@@ -2,7 +2,7 @@ require 'csv_to_popolo'
 require 'minitest/autorun'
 
 describe 'multivalue_separator' do
-  subject { Popolo::CSV.new('t/data/multiple_contacts_in_cells.csv') }
+  subject { Popolo::CSV.new('t/data/multiple_values_in_cells.csv') }
 
   let(:pers) { subject.data[:persons] }
   let(:cameron) { pers.find { |p| p[:name] == 'David Cameron' } }
@@ -25,16 +25,23 @@ describe 'multivalue_separator' do
 
   it 'should include multiple Twitter usernames in both contact_details and links' do
     # Check the links first...
-    cameron[:links].count.must_equal 2
-    cameron[:links][0][:url].must_equal 'https://twitter.com/David_Cameron'
-    cameron[:links][0][:note].must_equal 'twitter'
-    cameron[:links][1][:url].must_equal 'https://twitter.com/Number10gov'
-    cameron[:links][1][:note].must_equal 'twitter'
+    twitter_links = cameron[:links].select { |l| l[:note] == 'twitter' }
+    twitter_links.count.must_equal 2
+    twitter_links[0][:url].must_equal 'https://twitter.com/David_Cameron'
+    twitter_links[1][:url].must_equal 'https://twitter.com/Number10gov'
     # Then the contact_details:
     twitter_contacts = cameron[:contact_details].select { |c| c[:type] == 'twitter' }
     twitter_contacts.count.must_equal 2
     twitter_contacts[0][:value].must_equal 'David_Cameron'
     twitter_contacts[1][:value].must_equal 'Number10gov'
+  end
+
+  it 'should include both Facebook usernames for David Cameron' do
+    facebook_links = cameron[:links].select { |l| l[:note] == 'facebook' }
+    facebook_links.count.must_equal 3
+    facebook_links[0][:url].must_equal 'https://facebook.com/DavidCameronOfficial'
+    facebook_links[1][:url].must_equal 'https://facebook.com/SomeOtherDavidCameron'
+    facebook_links[2][:url].must_equal 'https://facebook.com/UnqualifiedDavidCameron'
   end
 
 end

--- a/t/test_multivalue_separator.rb
+++ b/t/test_multivalue_separator.rb
@@ -51,4 +51,11 @@ describe 'multivalue_separator' do
     website_links[1][:url].must_equal 'https://www.conservatives.com/OurTeam/David_Cameron'
   end
 
+  it 'should include two images for John Doe and set the top-level image field' do
+    doe[:image].must_equal 'http://example.org/a.jpg'
+    doe[:images].count.must_equal 2
+    doe[:images][0][:url].must_equal 'http://example.org/a.jpg'
+    doe[:images][1][:url].must_equal 'http://example.org/b.png'
+  end
+
 end


### PR DESCRIPTION
This adds a `multivalue_separator` property (set to `;`) for all contact and link types
to allow you to specify, for example, multiple email address, homepages, etc. for
a person. This is the naive implementation suggested in the ticket, which doesn't
consider needing to be able to quote the separator, for example.

Fixes #90
