### PR TITLE
Add `Post`s from `legislative_membership_type`

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,4 @@
-0.21.0  2016-04-11
+0.22.0  2016-04-11
   - Create Posts when given a legislative_membership_type
 
 0.21.0  2016-03-21

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,6 @@
+0.21.0  2016-04-11
+  - Create Posts when given a legislative_membership_type
+
 0.21.0  2016-03-21
   - Allow for multi-value fields (thanks @mhl)
 

--- a/lib/csv_to_popolo.rb
+++ b/lib/csv_to_popolo.rb
@@ -108,6 +108,9 @@ class Popolo
       type: 'link',
       multivalue_separator: ';'
     },
+    legislative_membership_type: {
+      type: 'memtype',
+    },
     linkedin: {
       type: 'link',
       multivalue_separator: ';'
@@ -180,6 +183,7 @@ class Popolo
     }
 
     def _idify(str)
+      return if str.to_s.empty?
       str.downcase.gsub(/\s+/, '_')
     end
 
@@ -197,6 +201,7 @@ class Popolo
         persons:       persons,
         organizations: organizations,
         memberships:   memberships,
+        posts:         posts,
         events:        terms,
         areas:         areas,
         warnings:      warnings
@@ -257,6 +262,16 @@ class Popolo
       end
     end
 
+    def posts
+      @_posts ||= @csv.select { |r| r.key? :legislative_membership_type }.uniq { |r| r[:legislative_membership_type] }.map do |r|
+        {
+          id: "#{_idify(r[:legislative_membership_type])}",
+          label: r[:legislative_membership_type],
+          organization_id: 'legislature',
+        }
+      end
+    end
+
     def terms
       @_terms ||= @csv.select { |r| r.key? :term }.uniq { |r| r[:term] }.map do |r|
         {
@@ -290,6 +305,7 @@ class Popolo
         mem = {
           person_id:          r[:id],
           organization_id:    find_chamber_id(r[:chamber]) || 'legislature',
+          post_id:            _idify(r[:legislative_membership_type]),
           role:               'member',
           on_behalf_of_id:    r[:group_id] || find_party_id(r[:group]),
           area_id:            !r[:area_id].to_s.empty? ? r[:area_id] : !r[:area].to_s.empty? ? "area/#{_idify(r[:area])}" : nil,

--- a/lib/csv_to_popolo.rb
+++ b/lib/csv_to_popolo.rb
@@ -265,7 +265,7 @@ class Popolo
     def posts
       @_posts ||= @csv.select { |r| r.key? :legislative_membership_type }.uniq { |r| r[:legislative_membership_type] }.map do |r|
         {
-          id: "#{_idify(r[:legislative_membership_type])}",
+          id: _idify(r[:legislative_membership_type]),
           label: r[:legislative_membership_type],
           organization_id: 'legislature',
         }

--- a/lib/csv_to_popolo/version.rb
+++ b/lib/csv_to_popolo/version.rb
@@ -1,3 +1,3 @@
 module Popolo_CSV
-  VERSION = '0.21.0'
+  VERSION = '0.22.0'
 end

--- a/t/data/uganda.csv
+++ b/t/data/uganda.csv
@@ -1,0 +1,5 @@
+id,name,group,group_id,gender,term,constituency,legislative_membership_type
+mp_76,Francis Mukula,Independent,INDEP,male,10,Agule County,
+mp_277,Tom Aza Alero,National Resistance Movement,NRM,male,10,West Moyo,
+mp_292,Agnes Ameede,National Resistance Movement,NRM,female,10,Pallisa,Woman Representative
+mp_419,Alex Ndeezi,National Resistance Movement,NRM,male,10,,PWD

--- a/t/test_uganda.rb
+++ b/t/test_uganda.rb
@@ -14,18 +14,22 @@ describe 'monaco' do
 
   it 'should have no Post for a normal membership' do
     alero = memberships('mp_277').first
-    alero.key?(:post_id).must_equal false
+    alero[:post_id].must_be_nil
+    alero[:area_id].must_equal 'area/west_moyo'
   end
 
   it 'should have a Woman Representative post with an Area' do
     ameede = memberships('mp_292').first
     ameede[:post_id].must_equal 'woman_representative'
+    ameede[:area_id].must_equal 'area/pallisa'
   end
 
   it 'should have a PWD post with no Area' do
     ndeezi = memberships('mp_419').first
     ndeezi[:post_id].must_equal 'pwd'
+    ndeezi[:area_id].must_be_nil
   end
+
 
   it 'should have two Posts' do
     posts = subject.data[:posts].sort_by { |p| p[:id] }

--- a/t/test_uganda.rb
+++ b/t/test_uganda.rb
@@ -1,0 +1,44 @@
+
+require 'csv_to_popolo'
+require 'minitest/autorun'
+require 'pry'
+require 'json'
+
+
+describe 'monaco' do
+  subject { Popolo::CSV.new('t/data/uganda.csv') }
+
+  def memberships(id) 
+    subject.data[:memberships].find_all { |m| m[:person_id] == id } 
+  end
+
+  it 'should have no Post for a normal membership' do
+    alero = memberships('mp_277').first
+    alero.key?(:post_id).must_equal false
+  end
+
+  it 'should have a Woman Representative post with an Area' do
+    ameede = memberships('mp_292').first
+    ameede[:post_id].must_equal 'woman_representative'
+  end
+
+  it 'should have a PWD post with no Area' do
+    ndeezi = memberships('mp_419').first
+    ndeezi[:post_id].must_equal 'pwd'
+  end
+
+  it 'should have two Posts' do
+    posts = subject.data[:posts].sort_by { |p| p[:id] }
+    posts.count.must_equal 2
+    posts.first[:id].must_equal 'pwd'
+    posts.first[:label].must_equal 'PWD'
+    posts.first[:organization_id].must_equal 'legislature'
+
+    posts.last[:id].must_equal 'woman_representative'
+    posts.last[:label].must_equal 'Woman Representative'
+  end
+
+  it 'should have no warnings' do
+    subject.data[:warnings].must_be_nil
+  end
+end


### PR DESCRIPTION
If the data has a `legislative_membership_type` column, use this to
construct a Post, and reference that from the `membership`

i.e. rather than creating a plain membership of the form:

``` json
   {
     "person_id": "mp_292",
      "organization_id": "legislature",
      "role": "member",
      "on_behalf_of_id": "NRM",
      "area_id": "area/pallisa",
      "legislative_period_id": "term/10"
    }
```

 we (if `legislative_membership_type` is set to "Youth Representative")
 generate:

``` json
    {
      "person_id": "mp_292",
      "organization_id": "legislature",
      "post_id": "youth_representative",
      "role": "member",
      "on_behalf_of_id": "NRM",
      "area_id": "area/pallisa",
      "legislative_period_id": "term/10"
    }
```

 along with a corresponding `Post` of:

``` json
  "posts": [
    {
      "id": "youth_representative",
      "label": "Youth Representative",
      "organization_id": "legislature"
    }
  ]
```
