### PR TITLE
Handle whitespace around url separator

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,6 @@
+0.27.1 2016-10-13
+  - Bug fix to handle whitespace around URL separator.
+
 0.27.0 2016-10-04
   - Split URL only if separator is followed by 'http'
 

--- a/lib/csv_to_popolo.rb
+++ b/lib/csv_to_popolo.rb
@@ -154,7 +154,7 @@ class Popolo
     website:                     {
       type:                 'link',
       aliases:              %w(homepage href url site),
-      multivalue_separator: /;(?=http)/,
+      multivalue_separator: /\s*;\s*(?=http)/,
     },
     wikipedia:                   {
       type:                 'link',

--- a/lib/csv_to_popolo/version.rb
+++ b/lib/csv_to_popolo/version.rb
@@ -1,3 +1,3 @@
 module Popolo_CSV
-  VERSION = '0.27.0'.freeze
+  VERSION = '0.27.1'.freeze
 end

--- a/t/data/multiple_values_in_cells.csv
+++ b/t/data/multiple_values_in_cells.csv
@@ -1,3 +1,4 @@
 name,email,cell,mobile,twitter,facebook,homepage,image
 John Doe,foo@example.org,555;666,777 ; 888 ,,,,http://example.org/a.jpg;http://example.org/b.png
 David Cameron,camerond@parliament.uk;info@davidcameron.com,,,https://twitter.com/David_Cameron;@Number10gov;@david_cameron,https://www.facebook.com/DavidCameronOfficial/;https://en-gb.facebook.com/SomeOtherDavidCameron/ ; UnqualifiedDavidCameron,http://cameron.example.org;https://www.conservatives.com/OurTeam/David_Cameron,
+Duncan Clarke,clarked@parliament.uk;info@duncanclarke.com,,,https://twitter.com/Duncan_Clarke;@Number10gov;@duncan_clarke,https://www.facebook.com/DuncanClarkeOfficial/ ; https://en-gb.facebook.com/SomeOtherDuncanClarke/;UnqualifiedDuncanClarke,http://clarke.example.org ; https://www.conservatives.com/OurTeam/Duncan_Clarke,

--- a/t/test_multivalue_separator.rb
+++ b/t/test_multivalue_separator.rb
@@ -6,6 +6,7 @@ describe 'multivalue_separator' do
 
   let(:pers) { subject.data[:persons] }
   let(:cameron) { pers.find { |p| p[:name] == 'David Cameron' } }
+  let(:clarke) { pers.find { |p| p[:name] == 'Duncan Clarke' } }
   let(:doe) { pers.find { |p| p[:name] == 'John Doe' } }
 
   let(:australia) do
@@ -67,5 +68,12 @@ describe 'multivalue_separator' do
     links = member[:links].select { |l| l[:note] == 'website' }
     links.first[:url].must_equal 'http://parlinfo.aph.gov.au/parlInfo/search/display/display.w3p;query%3DId%3A%22handbook%2Fallmps%2FAK6%22'
     links.count.must_equal 1
+  end
+
+  it 'should split URLs when there is space around the separator' do
+    url1 = { note: 'website', url: 'http://clarke.example.org' }
+    url2 = { note: 'website', url: 'https://www.conservatives.com/OurTeam/Duncan_Clarke' }
+    clarke[:links].must_include url1
+    clarke[:links].must_include url2
   end
 end

--- a/t/test_multivalue_separator.rb
+++ b/t/test_multivalue_separator.rb
@@ -71,9 +71,8 @@ describe 'multivalue_separator' do
   end
 
   it 'should split URLs when there is space around the separator' do
-    url1 = { note: 'website', url: 'http://clarke.example.org' }
-    url2 = { note: 'website', url: 'https://www.conservatives.com/OurTeam/Duncan_Clarke' }
-    clarke[:links].must_include url1
-    clarke[:links].must_include url2
+    urls = clarke[:links].select { |l| l[:note] == 'website' }.map { |l| l[:url] }
+    urls.first.must_equal 'http://clarke.example.org'
+    urls.last.must_equal 'https://www.conservatives.com/OurTeam/Duncan_Clarke'
   end
 end


### PR DESCRIPTION
This PR fixes problem where URLs separated by " ; " were not being split.

Closes: https://github.com/tmtmtmtm/csv_to_popolo/issues/107
