### PR TITLE
WIP: Handle multiple honorific prefixes

### DIFF
--- a/lib/csv_to_popolo.rb
+++ b/lib/csv_to_popolo.rb
@@ -90,7 +90,8 @@ class Popolo
       ),
     },
     honorific_prefix:            {
-      type: 'asis',
+      type:                 'asis',
+      multivalue_separator: ';',
     },
     honorific_suffix:            {
       type: 'asis',
@@ -494,6 +495,10 @@ class Popolo
       end
     end
 
+    def honorific_prefixes
+      cell_values(:honorific_prefix) if given? :honorific_prefix
+    end
+
     def as_popolo
       popolo = {}
       as_is = MODEL.select { |_, v| v[:type] == 'asis' }.map { |k, _| k }
@@ -510,6 +515,8 @@ class Popolo
 
       popolo[:other_names] = per_language_names + alternate_names
       popolo[:other_names] << { name: @r[:other_name] } if given?(:other_name)
+
+      popolo[:honorific_prefix] = honorific_prefixes
 
       popolo[:contact_details] = contact_details
       popolo[:links] = links

--- a/t/data/samoa.csv
+++ b/t/data/samoa.csv
@@ -1,0 +1,51 @@
+name,honorific_prefix,party_id,party_name,area,term
+"Peniamina Leavaiseeta",Aeau,TS,"Tautua Samoa",Falealupo,16
+"Lepuiai Rico Tupai",Afamasaga,H,HRPP,"Aana Alofi Nu. 3",16
+"Faleulu Mauli",Afoa;Amituanai,H,HRPP,"Palauli Sisifo",16
+"Sepulona Moananu",Alaiasa;Moefaauouo;Malagaitutogiai,H,HRPP,"Anoamaa Sasae (East)",16
+"Alofa Tuuau",Aliimalemanu,H,HRPP,"Alataua Sisifo (West)",16
+"Fagaivalu Kenrick Samu",Amituanai,H,HRPP,"Aleipata Itupa i Luga",16
+"Sailele Malielegaoi",Auelua;Fatialofa;Lupesoliai;Tuilaepa;Dr,H,HRPP,Lepa,16
+"Isaia Lameko",Aumua,H,HRPP,"Falealili West",16
+"Iosefa Sopi",Faalogo,H,HRPP,Siumu,16
+"Katopau T. Ainuu",Faaolesa,H,HRPP,"Vaimauga Sisifo Nu.2",16
+"Pati Taulapapa",Faasootauloa,H,HRPP,"Gagaemauga Nu. 2",16
+"Rosa Duffy-Stowers",Faaulusau,H,HRPP,"Gagaifomauga Nu. 3",16
+"Kika Iemaima Stowers",Faimalotoa,H,HRPP,"Gagaifomauga Nu. 1",16
+"Wayne Fong",Faumuina;Asi;Pauli,H,HRPP,"Urban West",16
+Liuga,Faumuina;Tiatia;Faaolatane,H,HRPP,"Palauli le Falefa",16
+"Naomi Mataafa",Fiame,H,HRPP,Lotofaga,16
+"Samuelu Teo",Fuimaono;Teo,H,HRPP,"Falealili East",16
+"Amataga Alesana-Gidlow",Gatoloaifaana,H,HRPP,"Faasaleleaga Nu. 1",16
+"Setefano Taateo Tafili",Ili,TS,"Tautua Samoa","Aana Alofi Nu.2",16
+Leuatea,Laauli;Polataivao,H,HRPP,"Gagaifomauga Nu. 3",16
+"Pierre Lauofo",Lauofo;Fonotoe;Nuafesili,H,HRPP,"Anoamaa Sisifo",16
+"Fio Selafi Purcell",Lautafi,H,HRPP,Satupaitea,16
+"Ronnie Posini",Leaana,H,HRPP,"Safata West",16
+"Rimoni Aiafi",Lealailepule,H,HRPP,"Faleata i Sisifo",16
+"T. Toleafoa Faafisi",Leaupepe,H,HRPP,"Aana Alofi Nu.1 West",16
+"Victor Faafoi Tamapua",Lenatai,H,HRPP,"Vaimauga Sisifo Nu.1",16
+"Keneti Sio",Loau;Sola,H,HRPP,"Sagaga le Falefa",16
+"Natanielu Mua",Lopaoo,H,HRPP,"Vaisigano Nu. 1",16
+Laki,Mulipola;Leiataua,H,HRPP,"Aiga i le Tai",16
+"Talaimanu Keti",Nafoitoa,H,HRPP,"Gagaemauga No.3",16
+"Lose Niumata",Nonu,H,HRPP,"Safata East",16
+"Fiti Afoa Vaai",Olo,TS,"Tautua Samoa","Salega East",16
+"Niko Lee Hang",Papaliitele,H,HRPP,"Urban East",16
+"Sefo Taumata Pau",Pau,H,HRPP,"Faasaleleaga Nu. 2",16
+"Vaifou Tevagaena",Peseta,H,HRPP,"Faasaleleaga Nu. 4",16
+Pinati,Sala;Fata,H,HRPP,"Gagaemauga Nu. 1",16
+"John Ah Ching",Salausa,H,HRPP,"Faleata Sasae (East)",16
+"Ueligitone Seiuli",Seiuli,H,HRPP,"Sagaga le Usoga",16
+"Epa Tuioti",Sili,H,HRPP,"Faasaleleaga Nu. 1 East",16
+Mene,Sooalo;Umi;Feo,H,HRPP,"Gagaifomauga Nu. 2",16
+"Fetaiai Tauiliili Tuivasa",Sulamanaia,H,HRPP,"Vaimauga Sasae",16
+Lemi,Taefu,H,HRPP,"Falelatai & Samatau",16
+"Maluelue Tafua",Tafua,H,HRPP,"Aleipata Itupa i Lalo",16
+Esera,Tapulesatele;Ii,H,HRPP,"Vaisigano Nu. 2",16
+"Tionisio Hunt",Tialavea;Fea;Leniu,H,HRPP,"Vaa o Fonoti",16
+"Foleni Lio Tama Galu",Tofa,H,HRPP,"Faasaleleaga Nu. 3",16
+"Ken Vaafusuaga Poutoa",Toleafoa,H,HRPP,"Lefaga & Faleaseela",16
+"Aki Tuipea",Toomata,H,HRPP,"Salega West",16
+"Lisati Leleisiuao Palemene",Tuifaasisina;Misa,H,HRPP,"Palauli Sasae",16
+"Talalelei Tuitama",Tuitama,H,HRPP,"Aana Alofi Nu. 1 East",16

--- a/t/test_multivalue_separator.rb
+++ b/t/test_multivalue_separator.rb
@@ -13,6 +13,10 @@ describe 'multivalue_separator' do
     Popolo::CSV.new('t/data/australia.csv')
   end
 
+  let(:samoa) do
+    Popolo::CSV.new('t/data/samoa.csv')
+  end
+
   it 'should find both mobile numbers for John Doe' do
     doe[:contact_details].count.must_equal 3
     cell_contacts = doe[:contact_details].select { |c| c[:type] == 'cell' }
@@ -74,5 +78,11 @@ describe 'multivalue_separator' do
     urls = clarke[:links].select { |l| l[:note] == 'website' }.map { |l| l[:url] }
     urls.first.must_equal 'http://clarke.example.org'
     urls.last.must_equal 'https://www.conservatives.com/OurTeam/Duncan_Clarke'
+  end
+
+  it 'should split multiple honorific prefixes' do
+    member = samoa.data[:persons].find { |p| p[:name] == 'Pierre Lauofo' }
+    prefixes = member[:honorific_prefix]
+    prefixes.must_equal ["Lauofo", "Fonotoe", "Nuafesili"]
   end
 end

--- a/t/test_multivalue_separator.rb
+++ b/t/test_multivalue_separator.rb
@@ -83,6 +83,6 @@ describe 'multivalue_separator' do
   it 'should split multiple honorific prefixes' do
     member = samoa.data[:persons].find { |p| p[:name] == 'Pierre Lauofo' }
     prefixes = member[:honorific_prefix]
-    prefixes.must_equal ["Lauofo", "Fonotoe", "Nuafesili"]
+    prefixes.must_equal %w(Lauofo Fonotoe Nuafesili)
   end
 end


### PR DESCRIPTION
Currently honorific_prefix only takes a single value but for cases such as Samoa a member can have multiple prefixes.

The Samoan PM has the full title: 'Susuga Hon AUELUA FATIALOFA LUPESOLIAI TUILAEPA Dr Sailele Malielegaoi'

(http://www.palemene.ws/new/members-of-parliament/members-of-the-xvi-parliament/)

The names in uppercase are tribal names and are very much discrete parts as they can be listed in any order.

With this PR, honorific_prefix: now handles multiple values separated with a semi-colon.

Closes: #109