### PR TITLE
0.30 Do not produce Executive data

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,7 @@
+0.30.0 2019-04-09
+  - Positions outside the legislature (i.e. in a separate Executive org)
+    are no longer supported.
+
 0.29.0 2018-04-05
   - Better handling of Wikimedia links to sites other than Wikipedia.
 

--- a/lib/csv_to_popolo.rb
+++ b/lib/csv_to_popolo.rb
@@ -51,9 +51,6 @@ class Popolo
     end_date:                    {
       aliases: %w(end ended until to),
     },
-    executive:                   {
-      aliases: %w(post),
-    },
     facebook:                    {
       type:                 'link',
       multivalue_separator: ';',
@@ -245,11 +242,7 @@ class Popolo
     end
 
     def organizations
-      parties + chambers + legislatures + executive
-    end
-
-    def memberships
-      legislative_memberships + executive_memberships
+      parties + chambers + legislatures
     end
 
     def areas
@@ -307,7 +300,7 @@ class Popolo
     end
 
     def legislatures
-      legislative_memberships.count.zero? ? [] : [
+      memberships.count.zero? ? [] : [
         {
           id:             'legislature',
           name:           'Legislature',
@@ -316,15 +309,7 @@ class Popolo
       ]
     end
 
-    def executive
-      executive_memberships.count.zero? ? [] : [{
-        id:             'executive',
-        name:           'Executive',
-        classification: 'executive',
-      },]
-    end
-
-    def legislative_memberships
+    def memberships
       @_lmems ||= csv.map do |r|
         mem = {
           person_id:       r[:id],
@@ -338,18 +323,6 @@ class Popolo
           sources:         sources_for(r),
         }.reject { |_, v| v.nil? || v.empty? }
         mem[:legislative_period_id] = "term/#{_idify(r[:term])}" if r.key? :term
-        mem
-      end
-    end
-
-    def executive_memberships
-      @_emems ||= csv.select { |r| r.key?(:executive) && !r[:executive].to_s.empty? }.map do |r|
-        mem = {
-          person_id:       r[:id],
-          organization_id: 'executive',
-          role:            r[:executive],
-        }
-        mem[:legislative_period] = "term/#{_idify(r[:term])}" if r.key? :term
         mem
       end
     end

--- a/lib/csv_to_popolo/version.rb
+++ b/lib/csv_to_popolo/version.rb
@@ -1,3 +1,3 @@
 module Popolo_CSV
-  VERSION = '0.29.0'.freeze
+  VERSION = '0.30.0'.freeze
 end

--- a/t/test_bhutan.rb
+++ b/t/test_bhutan.rb
@@ -15,19 +15,18 @@ describe 'Bhutan' do
   let(:mp) { ppl.find { |i| i[:id] == '20' } }
 
   describe 'The Prime Minster' do
-    it 'should have two memberships' do
-      mems.count { |m| m[:person_id] == pm[:id] }.must_equal 2
+    it 'has a single membership' do
+      mems.count { |m| m[:person_id] == pm[:id] }.must_equal 1
     end
 
-    it 'should have Legislative Membership sources' do
+    it 'has a Legislative Membership with a source' do
       lm = mems.find { |m| m[:person_id] == pm[:id] && m[:organization_id] == 'legislature' }
       lm[:sources].count.must_equal 1
       lm[:sources].first[:url].must_include 'www.nab.gov.bt'
     end
 
-    it 'should not have Executive Membership sources' do
-      em = mems.find { |m| m[:person_id] == pm[:id] && m[:organization_id] == 'executive' }
-      em[:sources].must_be_nil
+    it 'has no Executive Memberships' do
+      mems.find { |m| m[:person_id] == pm[:id] && m[:organization_id] == 'executive' }.must_be_nil
     end
 
     it 'should have no Person source' do
@@ -36,11 +35,11 @@ describe 'Bhutan' do
   end
 
   describe 'A Plain MP' do
-    it 'should have only one membership' do
+    it 'has one membership' do
       mems.count { |m| m[:person_id] == mp[:id] }.must_equal 1
     end
 
-    it 'should have a legislative membership' do
+    it 'has a legislative membership' do
       legm.find { |m| m[:person_id] == mp[:id] }[:organization_id].must_equal 'legislature'
     end
   end
@@ -55,8 +54,8 @@ describe 'Bhutan' do
   end
 
   describe 'validation' do
-    it 'should have no warnings' do
-      subject.data[:warnings].must_be_nil
+    it 'warns about the executive column' do
+      subject.data[:warnings][:skipped].must_equal [:executive]
     end
   end
 end

--- a/t/test_wales.rb
+++ b/t/test_wales.rb
@@ -60,22 +60,23 @@ describe 'welsh assembly' do
   end
 
   describe 'First Minister' do
-    let(:executive) { orgs.find { |o| o[:id] == 'executive' } }
     let(:fmin) { pers.find   { |p| p[:id] == '102' } }
     let(:fmem) { mems.select { |m| m[:person_id] == fmin[:id] } }
 
-    it 'should have two memberships' do
-      fmem.count.must_equal 2
+    it 'has a single membership' do
+      fmem.count.must_equal 1
     end
 
-    it 'should have Assembly membership' do
+    it 'has the Assembly membership' do
       fmem.find { |m| m[:role] == 'member' }[:area_id].must_equal 'area/bridgend'
     end
 
-    it 'should have Executive membership' do
-      execm = fmem.select { |m| m[:organization_id] == executive[:id] }
-      execm.count.must_equal 1
-      execm.first[:role].must_equal 'The First Minister'
+    it 'has no Executive org' do
+      orgs.find { |o| o[:id] == 'executive' }.must_be_nil
+    end
+
+    it 'has no Executive memberships' do
+      fmem.find { |m| m[:organization_id] != 'legislature' }.must_be_nil
     end
   end
 


### PR DESCRIPTION
Previously, if there was an 'executive' or 'post' column, we would turn
that into a set of memberships of an executive body, separately from the
other memberships to the legislative body. This was unneeded complexity,
and all known users of this code needed to post-process the data to handle
this in odd ways. So we no longer support it.