### PR TITLE
0.30: No longer partitiion by a 'house'

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,7 @@
+0.31.0 2019-04-09
+  - Positions acros multiple distinct chambers/houses of the legislature are no
+    longer supported. We now assume that those will be separate Popolo files.
+
 0.30.0 2019-04-09
   - Positions outside the legislature (i.e. in a separate Executive org)
     are no longer supported.

--- a/lib/csv_to_popolo.rb
+++ b/lib/csv_to_popolo.rb
@@ -36,9 +36,6 @@ class Popolo
       type:                 'contact',
       multivalue_separator: ';',
     },
-    chamber:                     {
-      aliases: %w(house),
-    },
     death_date:                  {
       aliases: %w(dod date_of_death),
       type:    'asis',
@@ -242,7 +239,7 @@ class Popolo
     end
 
     def organizations
-      parties + chambers + legislatures
+      parties + legislatures
     end
 
     def areas
@@ -261,17 +258,6 @@ class Popolo
           id:             r[:group_id] || "party/#{_idify(r[:group])}",
           name:           r[:group],
           classification: 'party',
-        }
-      end
-    end
-
-    def chambers
-      # TODO: the chambers should be members of the Legislature
-      @_chambers ||= csv.select { |r| r.key? :chamber }.uniq { |r| r[:chamber] }.map do |r|
-        {
-          id:             r[:chamber_id] || "chamber/#{_idify(r[:chamber])}",
-          name:           r[:chamber],
-          classification: 'chamber',
         }
       end
     end
@@ -313,7 +299,7 @@ class Popolo
       @_lmems ||= csv.map do |r|
         mem = {
           person_id:       r[:id],
-          organization_id: find_chamber_id(r[:chamber]) || 'legislature',
+          organization_id: 'legislature',
           post_id:         _idify(r[:legislative_membership_type]),
           role:            'member',
           on_behalf_of_id: r[:group_id] || find_party_id(r[:group]),
@@ -349,10 +335,6 @@ class Popolo
 
     def find_party_id(name)
       (parties.find { |p| p[:name].to_s.downcase == name.to_s.downcase } || return)[:id]
-    end
-
-    def find_chamber_id(name)
-      (chambers.find { |p| p[:name] == name } || return)[:id]
     end
 
     # TODO: move this into a Row class

--- a/lib/csv_to_popolo/version.rb
+++ b/lib/csv_to_popolo/version.rb
@@ -1,3 +1,3 @@
 module Popolo_CSV
-  VERSION = '0.30.0'.freeze
+  VERSION = '0.31.0'.freeze
 end

--- a/t/test_parlamento.rb
+++ b/t/test_parlamento.rb
@@ -35,10 +35,9 @@ describe 'parlamento' do
       subject.data[:areas].find { |a| a[:id] == leg_mem[:area_id] }[:name].must_equal 'Lazio'
     end
 
-    it 'should be in correct chamber' do
+    it 'is in the legislature' do
       leg_mem = pmems.find { |m| m[:role] == 'member' }
-      chamber = orgs.find { |o| o[:id] == leg_mem[:organization_id] }
-      chamber[:name].must_equal 'Senate'
+      leg_mem[:organization_id].must_equal 'legislature'
     end
   end
 
@@ -66,16 +65,15 @@ describe 'parlamento' do
       subject.data[:areas].find { |a| a[:id] == leg_mem[:area_id] }[:name].must_equal 'Sicilia 2'
     end
 
-    it 'should be in correct chamber' do
+    it 'is in the legislature' do
       leg_mem = pmems.find { |m| m[:role] == 'member' }
-      chamber = orgs.find { |o| o[:id] == leg_mem[:organization_id] }
-      chamber[:name].must_equal 'Chamber of Deputies'
+      leg_mem[:organization_id].must_equal 'legislature'
     end
   end
 
   describe 'validation' do
-    it 'should have no warnings' do
-      subject.data[:warnings].must_be_nil
+    it 'should skip the house column' do
+      subject.data[:warnings][:skipped].must_include :house
     end
   end
 end


### PR DESCRIPTION
Previously, if there was a 'house' or 'chamber' column, we would create
separate sub-legislature organizations, and make the memberships be of
those instead.

This is unneeded complexity, and all known users of this code needed to
post-process the data to handle this in odd ways. So we no longer support
this approach. It is now assumed that different houses will be in separate
Popolo files.